### PR TITLE
Qiskit 2.0 + pyqir 0.12 Migration

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,5 +8,5 @@ jinja2==3.1.4
 twine==6.1.0
 pytest==7.4.4
 black==24.3.0
-pyqir==0.10.0
-qiskit>=1.0.0
+pyqir==0.12.4
+qiskit>=2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,6 @@ classifiers =
 	License :: OSI Approved :: MIT License
 	Natural Language :: English
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.8
-	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
 	Programming Language :: Python :: 3.12
@@ -28,10 +26,10 @@ classifiers =
 package_dir =
 	= src
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.10
 install_requires =
-	qiskit>=1.0.0,<2.0
-	pyqir>=0.10.0,<0.11.0
+	qiskit>=2.0.0,<3.0
+	pyqir>=0.12.0,<0.13
 
 [options.extras_require]
 test = pytest

--- a/src/qiskit_qir/capability.py
+++ b/src/qiskit_qir/capability.py
@@ -45,14 +45,15 @@ class CapabilityError(Exception):
         gate_params = ",".join(["param(%s)" % bit_labels[c] for c in cargs])
         qubit_params = ",".join(["%s" % bit_labels[q] for q in qargs])
         instruction_name = instruction.name
-        if instruction.condition is not None:
+        condition = getattr(instruction, "condition", None)
+        if condition is not None:
             # condition should be a
             # - tuple (ClassicalRegister, int)
             # - tuple (Clbit, bool)
             # - tuple (Clbit, int)
-            if isinstance(instruction.condition[0], Clbit):
-                bit: Clbit = instruction.condition[0]
-                value: Union[int, bool] = instruction.condition[1]
+            if isinstance(condition[0], Clbit):
+                bit: Clbit = condition[0]
+                value: Union[int, bool] = condition[1]
                 instruction_name = "if(%s[%d] == %s) %s" % (
                     bit._register.name,
                     bit._index,
@@ -60,8 +61,8 @@ class CapabilityError(Exception):
                     instruction_name,
                 )
             else:
-                register: ClassicalRegister = instruction.condition[0]
-                value: int = instruction.condition[1]
+                register: ClassicalRegister = condition[0]
+                value: int = condition[1]
                 instruction_name = "if(%s == %d) %s" % (
                     register._name,
                     value,

--- a/src/qiskit_qir/capability.py
+++ b/src/qiskit_qir/capability.py
@@ -64,7 +64,7 @@ class CapabilityError(Exception):
                 register: ClassicalRegister = condition[0]
                 value: int = condition[1]
                 instruction_name = "if(%s == %d) %s" % (
-                    register._name,
+                    register.name,
                     value,
                     instruction_name,
                 )

--- a/src/qiskit_qir/elements.py
+++ b/src/qiskit_qir/elements.py
@@ -5,7 +5,7 @@
 from typing import List, Optional, Union
 from pyqir import Module, Context
 from qiskit import ClassicalRegister, QuantumRegister
-from qiskit.circuit.bit import Bit
+from qiskit.circuit import Bit
 from qiskit.circuit.quantumcircuit import QuantumCircuit, Instruction
 from abc import ABCMeta, abstractmethod
 
@@ -90,8 +90,12 @@ class QiskitModule:
         elements.extend(_Register.from_element_list(circuit.cregs))
 
         # Instructions
-        for instruction, qargs, cargs in circuit._data:
-            elements.append(_Instruction(instruction, qargs, cargs))
+        for circuit_instruction in circuit.data:
+            elements.append(_Instruction(
+                circuit_instruction.operation,
+                list(circuit_instruction.qubits),
+                list(circuit_instruction.clbits),
+            ))
 
         if module is None:
             module = Module(Context(), circuit.name)

--- a/src/qiskit_qir/visitor.py
+++ b/src/qiskit_qir/visitor.py
@@ -8,7 +8,7 @@ from abc import ABCMeta, abstractmethod
 from qiskit import ClassicalRegister, QuantumRegister
 from qiskit.circuit import Qubit, Clbit
 from qiskit.circuit.instruction import Instruction
-from qiskit.circuit.bit import Bit
+from qiskit.circuit import Bit
 import pyqir.qis as qis
 import pyqir.rt as rt
 import pyqir
@@ -24,7 +24,7 @@ from pyqir import (
     PointerType,
     const,
     entry_point,
-    qubit_id,
+    ptr_id,
 )
 from typing import List, Union
 
@@ -301,11 +301,11 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
             or "mz" == instruction.name
         ):
             for qubit, result in zip(qubits, results):
-                self._measured_qubits[qubit_id(qubit)] = True
+                self._measured_qubits[ptr_id(qubit)] = True
                 qis.mz(self._builder, qubit, result)
         elif "measure_x" == instruction.name:
             for qubit, result in zip(qubits, results):
-                self._measured_qubits[qubit_id(qubit)] = True
+                self._measured_qubits[ptr_id(qubit)] = True
                 self._call_mx_instruction(qubit, result)
         else:
             if not self._capabilities & Capability.QUBIT_USE_AFTER_MEASUREMENT:
@@ -314,7 +314,7 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
                 # back into this function with a supported name and we'll
                 # verify at that time
                 if instruction.name in _SUPPORTED_INSTRUCTIONS:
-                    if any(map(self._measured_qubits.get, map(qubit_id, qubits))):
+                    if any(map(self._measured_qubits.get, map(ptr_id, qubits))):
                         raise QubitUseAfterMeasurementError(
                             self._qiskitModule.circuit,
                             instruction,
@@ -377,7 +377,7 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
                 qis.z(self._builder, *qubits)
             elif "id" == instruction.name:
                 # See: https://github.com/qir-alliance/pyqir/issues/74
-                qubit = pyqir.qubit(self._module.context, qubit_id(*qubits))
+                qubit = pyqir.qubit(self._module.context, ptr_id(*qubits))
                 qis.x(self._builder, qubit)
                 qis.x(self._builder, qubit)
             elif instruction.definition:

--- a/src/qiskit_qir/visitor.py
+++ b/src/qiskit_qir/visitor.py
@@ -9,6 +9,7 @@ from qiskit import ClassicalRegister, QuantumRegister
 from qiskit.circuit import Qubit, Clbit
 from qiskit.circuit.instruction import Instruction
 from qiskit.circuit import Bit
+from qiskit.circuit.controlflow import IfElseOp
 import pyqir.qis as qis
 import pyqir.rt as rt
 import pyqir
@@ -26,7 +27,7 @@ from pyqir import (
     entry_point,
     ptr_id,
 )
-from typing import List, Union
+from typing import List
 
 from qiskit_qir.capability import (
     Capability,
@@ -220,85 +221,20 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
         instruction: Instruction,
         qargs: List[Bit],
         cargs: List[Bit],
-        skip_condition=False,
     ):
+        if isinstance(instruction, IfElseOp):
+            self._visit_if_else_op(instruction, qargs, cargs)
+            return
+
         qlabels = [self._qubit_labels.get(bit) for bit in qargs]
         clabels = [self._clbit_labels.get(bit) for bit in cargs]
         qubits = [pyqir.qubit(self._module.context, n) for n in qlabels]
         results = [pyqir.result(self._module.context, n) for n in clabels]
 
-        if (
-            instruction.condition is not None
-        ) and not self._capabilities & Capability.CONDITIONAL_BRANCHING_ON_RESULT:
-            raise ConditionalBranchingOnResultError(
-                self._qiskitModule.circuit, instruction, qargs, cargs, self._profile
-            )
-
         labels = ", ".join([str(l) for l in qlabels + clabels])
-        if instruction.condition is None or skip_condition:
-            _log.debug(f"Visiting instruction '{instruction.name}' ({labels})")
+        _log.debug(f"Visiting instruction '{instruction.name}' ({labels})")
 
-        if instruction.condition is not None and skip_condition is False:
-            _log.debug(
-                f"Visiting condition for instruction '{instruction.name}' ({labels})"
-            )
-
-            if isinstance(instruction.condition[0], Clbit):
-                bit_label = self._clbit_labels.get(instruction.condition[0])
-                conditions = [pyqir.result(self._module.context, bit_label)]
-            else:
-                conditions = [
-                    pyqir.result(self._module.context, self._clbit_labels.get(bit))
-                    for bit in instruction.condition[0]
-                ]
-
-            # Convert value into a bitstring of the same length as classical register
-            # condition should be a
-            # - tuple (ClassicalRegister, int)
-            # - tuple (Clbit, bool)
-            # - tuple (Clbit, int)
-            if isinstance(instruction.condition[0], Clbit):
-                bit: Clbit = instruction.condition[0]
-                value: Union[int, bool] = instruction.condition[1]
-                if value:
-                    values = "1"
-                else:
-                    values = "0"
-            else:
-                register: ClassicalRegister = instruction.condition[0]
-                value: int = instruction.condition[1]
-                values = format(value, f"0{register.size}b")
-
-            # Add branches recursively for each bit in the bitstring
-            def __visit():
-                self.visit_instruction(instruction, qargs, cargs, skip_condition=True)
-
-            def _branch(conditions_values):
-                try:
-                    cond, val = next(conditions_values)
-
-                    def __branch():
-                        qis.if_result(
-                            self._builder,
-                            cond,
-                            one=_branch(conditions_values) if val == "1" else None,
-                            zero=_branch(conditions_values) if val == "0" else None,
-                        )
-
-                except StopIteration:
-                    return __visit
-                else:
-                    return __branch
-
-            if len(conditions) < len(values):
-                raise ValueError(
-                    f"Value {value} is larger than register width {len(conditions)}."
-                )
-
-            # qiskit has the most significant bit on the right, so we
-            # must reverse the bit array for comparisons.
-            _branch(zip(conditions, values[::-1]))()
-        elif (
+        if (
             "measure" == instruction.name
             or "m" == instruction.name
             or "mz" == instruction.name
@@ -394,6 +330,68 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
     Please transpile using the list of supported gates: {_SUPPORTED_INSTRUCTIONS}."
                 )
 
+    def _visit_if_else_op(
+        self,
+        op: IfElseOp,
+        qargs: List[Bit],
+        cargs: List[Bit],
+    ):
+        if not self._capabilities & Capability.CONDITIONAL_BRANCHING_ON_RESULT:
+            raise ConditionalBranchingOnResultError(
+                self._qiskitModule.circuit, op, qargs, cargs, self._profile
+            )
+
+        cond_target, cond_value = op.condition
+
+        # condition is (Clbit, bool|int) or (ClassicalRegister, int)
+        if isinstance(cond_target, Clbit):
+            conditions = [
+                pyqir.result(self._module.context, self._clbit_labels.get(cond_target))
+            ]
+            values = "1" if cond_value else "0"
+        else:
+            conditions = [
+                pyqir.result(self._module.context, self._clbit_labels.get(bit))
+                for bit in cond_target
+            ]
+            values = format(cond_value, f"0{cond_target.size}b")
+
+        if len(conditions) < len(values):
+            raise ValueError(
+                f"Value {cond_value} is larger than register width {len(conditions)}."
+            )
+
+        true_body = op.blocks[0]
+
+        def __visit_body():
+            for circuit_instr in true_body.data:
+                self.visit_instruction(
+                    circuit_instr.operation,
+                    list(circuit_instr.qubits),
+                    list(circuit_instr.clbits),
+                )
+
+        def _branch(conditions_values):
+            try:
+                cond, val = next(conditions_values)
+
+                def __branch():
+                    qis.if_result(
+                        self._builder,
+                        cond,
+                        one=_branch(conditions_values) if val == "1" else None,
+                        zero=_branch(conditions_values) if val == "0" else None,
+                    )
+
+            except StopIteration:
+                return __visit_body
+            else:
+                return __branch
+
+        # qiskit has the most significant bit on the right, so we
+        # must reverse the bit array for comparisons.
+        _branch(zip(conditions, values[::-1]))()
+
     def ir(self) -> str:
         return str(self._module)
 
@@ -416,7 +414,7 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
         assert mod is not None
         void = pyqir.Type.void(mod.context)
         double = pyqir.Type.double(mod.context)
-        function_type = FunctionType(void, [double, pyqir.qubit_type(mod.context)])
+        function_type = FunctionType(void, [double, PointerType(IntType(mod.context, 8))])
         return Function(
             function_type, Linkage.EXTERNAL, "__quantum__qis__delay__body", mod
         )
@@ -426,7 +424,7 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
         assert mod is not None
         void = pyqir.Type.void(mod.context)
         boolean = pyqir.IntType(mod.context, width=1)
-        function_type = FunctionType(void, [boolean, pyqir.qubit_type(mod.context)])
+        function_type = FunctionType(void, [boolean, PointerType(IntType(mod.context, 8))])
         return Function(
             function_type,
             Linkage.EXTERNAL,
@@ -439,7 +437,7 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
         assert mod is not None
         void = pyqir.Type.void(mod.context)
         function_type = FunctionType(
-            void, [pyqir.qubit_type(mod.context), pyqir.result_type(mod.context)]
+            void, [PointerType(IntType(mod.context, 8)), PointerType(IntType(mod.context, 8))]
         )
         return Function(
             function_type, Linkage.EXTERNAL, f"__quantum__qis__mx__body", mod

--- a/src/qiskit_qir/visitor.py
+++ b/src/qiskit_qir/visitor.py
@@ -204,7 +204,10 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
                 f"Composite instruction {instruction.name} called with the wrong number of classical bits; \
 {subcircuit.num_clbits} expected, {len(cargs)} provided"
             )
-        for inst, i_qargs, i_cargs in subcircuit.data:
+        for circuit_instr in subcircuit.data:
+            inst = circuit_instr.operation
+            i_qargs = circuit_instr.qubits
+            i_cargs = circuit_instr.clbits
             mapped_qbits = [qargs[subcircuit.qubits.index(i)] for i in i_qargs]
             mapped_clbits = [cargs[subcircuit.clbits.index(i)] for i in i_cargs]
             _log.debug(

--- a/src/qiskit_qir/visitor.py
+++ b/src/qiskit_qir/visitor.py
@@ -10,6 +10,7 @@ from qiskit.circuit import Qubit, Clbit
 from qiskit.circuit.instruction import Instruction
 from qiskit.circuit import Bit
 from qiskit.circuit.controlflow import IfElseOp
+from qiskit.circuit.classical import expr as qiskit_expr
 import pyqir.qis as qis
 import pyqir.rt as rt
 import pyqir
@@ -339,6 +340,19 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
         if not self._capabilities & Capability.CONDITIONAL_BRANCHING_ON_RESULT:
             raise ConditionalBranchingOnResultError(
                 self._qiskitModule.circuit, op, qargs, cargs, self._profile
+            )
+
+        if len(op.blocks) > 1:
+            raise NotImplementedError(
+                "IfElseOp with an else branch is not yet supported. "
+                "Only if-without-else is currently translated to QIR."
+            )
+
+        if not isinstance(op.condition, tuple):
+            raise NotImplementedError(
+                f"Classical expression conditions (expr API) are not yet supported. "
+                f"Use the tuple-based condition: (ClassicalRegister, int) or (Clbit, bool). "
+                f"Got: {op.condition!r}"
             )
 
         cond_target, cond_value = op.condition

--- a/tests/resources/test_single_clbit_variations_falsy.ll
+++ b/tests/resources/test_single_clbit_variations_falsy.ll
@@ -1,32 +1,29 @@
 ; ModuleID = 'test_single_clbit_variations_falsy'
 source_filename = "test_single_clbit_variations"
 
-%Qubit = type opaque
-%Result = type opaque
-
 define void @test_single_clbit_variations() #0 {
 entry:
-  call void @__quantum__rt__initialize(i8* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  %0 = call i1 @__quantum__qis__read_result__body(ptr null)
   br i1 %0, label %then, label %else
 
 then:                                             ; preds = %entry
   br label %continue
 
 else:                                             ; preds = %entry
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
   br label %continue
 
 continue:                                         ; preds = %else, %then
   ret void
 }
 
-declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__rt__initialize(ptr)
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
 attributes #1 = { "irreversible" }

--- a/tests/resources/test_single_clbit_variations_truthy.ll
+++ b/tests/resources/test_single_clbit_variations_truthy.ll
@@ -1,18 +1,15 @@
 ; ModuleID = 'test_single_clbit_variations_truthy'
 source_filename = "test_single_clbit_variations"
 
-%Qubit = type opaque
-%Result = type opaque
-
 define void @test_single_clbit_variations() #0 {
 entry:
-  call void @__quantum__rt__initialize(i8* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  %0 = call i1 @__quantum__qis__read_result__body(ptr null)
   br i1 %0, label %then, label %else
 
 then:                                             ; preds = %entry
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
   br label %continue
 
 else:                                             ; preds = %entry
@@ -22,11 +19,11 @@ continue:                                         ; preds = %else, %then
   ret void
 }
 
-declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__rt__initialize(ptr)
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
 attributes #1 = { "irreversible" }

--- a/tests/resources/test_single_register_index_variations_falsy.ll
+++ b/tests/resources/test_single_register_index_variations_falsy.ll
@@ -1,32 +1,29 @@
 ; ModuleID = 'test_single_register_index_variations_falsy'
 source_filename = "test_single_register_index_variations"
 
-%Qubit = type opaque
-%Result = type opaque
-
 define void @test_single_register_index_variations() #0 {
 entry:
-  call void @__quantum__rt__initialize(i8* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  %0 = call i1 @__quantum__qis__read_result__body(ptr null)
   br i1 %0, label %then, label %else
 
 then:                                             ; preds = %entry
   br label %continue
 
 else:                                             ; preds = %entry
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
   br label %continue
 
 continue:                                         ; preds = %else, %then
   ret void
 }
 
-declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__rt__initialize(ptr)
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
 attributes #1 = { "irreversible" }

--- a/tests/resources/test_single_register_index_variations_truthy.ll
+++ b/tests/resources/test_single_register_index_variations_truthy.ll
@@ -1,18 +1,15 @@
 ; ModuleID = 'test_single_register_index_variations_truthy'
 source_filename = "test_single_register_index_variations"
 
-%Qubit = type opaque
-%Result = type opaque
-
 define void @test_single_register_index_variations() #0 {
 entry:
-  call void @__quantum__rt__initialize(i8* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  %0 = call i1 @__quantum__qis__read_result__body(ptr null)
   br i1 %0, label %then, label %else
 
 then:                                             ; preds = %entry
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
   br label %continue
 
 else:                                             ; preds = %entry
@@ -22,11 +19,11 @@ continue:                                         ; preds = %else, %then
   ret void
 }
 
-declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__rt__initialize(ptr)
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
 attributes #1 = { "irreversible" }

--- a/tests/resources/test_single_register_variations_falsy.ll
+++ b/tests/resources/test_single_register_variations_falsy.ll
@@ -1,21 +1,18 @@
 ; ModuleID = 'test_single_register_variations_falsy'
 source_filename = "test_single_register_variations"
 
-%Qubit = type opaque
-%Result = type opaque
-
 define void @test_single_register_variations() #0 {
 entry:
-  call void @__quantum__rt__initialize(i8* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  %0 = call i1 @__quantum__qis__read_result__body(ptr null)
   br i1 %0, label %then, label %else
 
 then:                                             ; preds = %entry
   br label %continue
 
 else:                                             ; preds = %entry
-  %1 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
+  %1 = call i1 @__quantum__qis__read_result__body(ptr inttoptr (i64 1 to ptr))
   br i1 %1, label %then1, label %else2
 
 continue:                                         ; preds = %continue3, %then
@@ -25,18 +22,18 @@ then1:                                            ; preds = %else
   br label %continue3
 
 else2:                                            ; preds = %else
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
   br label %continue3
 
 continue3:                                        ; preds = %else2, %then1
   br label %continue
 }
 
-declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__rt__initialize(ptr)
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
 attributes #1 = { "irreversible" }

--- a/tests/resources/test_single_register_variations_truthy.ll
+++ b/tests/resources/test_single_register_variations_truthy.ll
@@ -1,18 +1,15 @@
 ; ModuleID = 'test_single_register_variations_truthy'
 source_filename = "test_single_register_variations"
 
-%Qubit = type opaque
-%Result = type opaque
-
 define void @test_single_register_variations() #0 {
 entry:
-  call void @__quantum__rt__initialize(i8* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  %0 = call i1 @__quantum__qis__read_result__body(ptr null)
   br i1 %0, label %then, label %else
 
 then:                                             ; preds = %entry
-  %1 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
+  %1 = call i1 @__quantum__qis__read_result__body(ptr inttoptr (i64 1 to ptr))
   br i1 %1, label %then1, label %else2
 
 else:                                             ; preds = %entry
@@ -25,18 +22,18 @@ then1:                                            ; preds = %then
   br label %continue3
 
 else2:                                            ; preds = %then
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
   br label %continue3
 
 continue3:                                        ; preds = %else2, %then1
   br label %continue
 }
 
-declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__rt__initialize(ptr)
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
 attributes #1 = { "irreversible" }

--- a/tests/resources/test_two_bit_register_variations_falsy.ll
+++ b/tests/resources/test_two_bit_register_variations_falsy.ll
@@ -1,22 +1,19 @@
 ; ModuleID = 'test_two_bit_register_variations_falsy'
 source_filename = "test_two_bit_register_variations"
 
-%Qubit = type opaque
-%Result = type opaque
-
 define void @test_two_bit_register_variations() #0 {
 entry:
-  call void @__quantum__rt__initialize(i8* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+  %0 = call i1 @__quantum__qis__read_result__body(ptr null)
   br i1 %0, label %then, label %else
 
 then:                                             ; preds = %entry
   br label %continue
 
 else:                                             ; preds = %entry
-  %1 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
+  %1 = call i1 @__quantum__qis__read_result__body(ptr inttoptr (i64 1 to ptr))
   br i1 %1, label %then1, label %else2
 
 continue:                                         ; preds = %continue3, %then
@@ -26,18 +23,18 @@ then1:                                            ; preds = %else
   br label %continue3
 
 else2:                                            ; preds = %else
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
   br label %continue3
 
 continue3:                                        ; preds = %else2, %then1
   br label %continue
 }
 
-declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__rt__initialize(ptr)
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="3" "required_num_results"="3" }
 attributes #1 = { "irreversible" }

--- a/tests/resources/test_two_bit_register_variations_three.ll
+++ b/tests/resources/test_two_bit_register_variations_three.ll
@@ -1,19 +1,16 @@
 ; ModuleID = 'test_two_bit_register_variations_three'
 source_filename = "test_two_bit_register_variations"
 
-%Qubit = type opaque
-%Result = type opaque
-
 define void @test_two_bit_register_variations() #0 {
 entry:
-  call void @__quantum__rt__initialize(i8* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+  %0 = call i1 @__quantum__qis__read_result__body(ptr null)
   br i1 %0, label %then, label %else
 
 then:                                             ; preds = %entry
-  %1 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
+  %1 = call i1 @__quantum__qis__read_result__body(ptr inttoptr (i64 1 to ptr))
   br i1 %1, label %then1, label %else2
 
 else:                                             ; preds = %entry
@@ -23,7 +20,7 @@ continue:                                         ; preds = %continue3, %else
   ret void
 
 then1:                                            ; preds = %then
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
   br label %continue3
 
 else2:                                            ; preds = %then
@@ -33,11 +30,11 @@ continue3:                                        ; preds = %else2, %then1
   br label %continue
 }
 
-declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__rt__initialize(ptr)
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="3" "required_num_results"="3" }
 attributes #1 = { "irreversible" }

--- a/tests/resources/test_two_bit_register_variations_truthy.ll
+++ b/tests/resources/test_two_bit_register_variations_truthy.ll
@@ -1,19 +1,16 @@
 ; ModuleID = 'test_two_bit_register_variations_truthy'
 source_filename = "test_two_bit_register_variations"
 
-%Qubit = type opaque
-%Result = type opaque
-
 define void @test_two_bit_register_variations() #0 {
 entry:
-  call void @__quantum__rt__initialize(i8* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+  %0 = call i1 @__quantum__qis__read_result__body(ptr null)
   br i1 %0, label %then, label %else
 
 then:                                             ; preds = %entry
-  %1 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
+  %1 = call i1 @__quantum__qis__read_result__body(ptr inttoptr (i64 1 to ptr))
   br i1 %1, label %then1, label %else2
 
 else:                                             ; preds = %entry
@@ -26,18 +23,18 @@ then1:                                            ; preds = %then
   br label %continue3
 
 else2:                                            ; preds = %then
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
   br label %continue3
 
 continue3:                                        ; preds = %else2, %then1
   br label %continue
 }
 
-declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__rt__initialize(ptr)
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="3" "required_num_results"="3" }
 attributes #1 = { "irreversible" }

--- a/tests/resources/test_two_bit_register_variations_two.ll
+++ b/tests/resources/test_two_bit_register_variations_two.ll
@@ -1,29 +1,26 @@
 ; ModuleID = 'test_two_bit_register_variations_two'
 source_filename = "test_two_bit_register_variations"
 
-%Qubit = type opaque
-%Result = type opaque
-
 define void @test_two_bit_register_variations() #0 {
 entry:
-  call void @__quantum__rt__initialize(i8* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
+  call void @__quantum__rt__initialize(ptr null)
+  call void @__quantum__qis__mz__body(ptr null, ptr null)
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 1 to ptr), ptr inttoptr (i64 1 to ptr))
+  %0 = call i1 @__quantum__qis__read_result__body(ptr null)
   br i1 %0, label %then, label %else
 
 then:                                             ; preds = %entry
   br label %continue
 
 else:                                             ; preds = %entry
-  %1 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
+  %1 = call i1 @__quantum__qis__read_result__body(ptr inttoptr (i64 1 to ptr))
   br i1 %1, label %then1, label %else2
 
 continue:                                         ; preds = %continue3, %then
   ret void
 
 then1:                                            ; preds = %else
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+  call void @__quantum__qis__mz__body(ptr inttoptr (i64 2 to ptr), ptr inttoptr (i64 2 to ptr))
   br label %continue3
 
 else2:                                            ; preds = %else
@@ -33,11 +30,11 @@ continue3:                                        ; preds = %else2, %then1
   br label %continue
 }
 
-declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__rt__initialize(ptr)
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+declare void @__quantum__qis__mz__body(ptr, ptr writeonly) #1
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(ptr)
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="3" "required_num_results"="3" }
 attributes #1 = { "irreversible" }

--- a/tests/test_c_if.py
+++ b/tests/test_c_if.py
@@ -38,7 +38,8 @@ def test_single_clbit_variations_falsy(value: bool) -> None:
     circuit.add_register(cr)
     circuit.measure(0, 0)
     bit: Clbit = cr[0]
-    circuit.measure(1, 1).c_if(bit, value)
+    with circuit.if_test((bit, value)):
+        circuit.measure(1, 1)
 
     generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
     compare_reference_ir(generated_bitcode, "test_single_clbit_variations_falsy")
@@ -51,7 +52,8 @@ def test_single_clbit_variations_truthy(value: bool) -> None:
     circuit.add_register(cr)
     circuit.measure(0, 0)
     bit: Clbit = cr[0]
-    circuit.measure(1, 1).c_if(bit, value)
+    with circuit.if_test((bit, value)):
+        circuit.measure(1, 1)
 
     generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
     compare_reference_ir(generated_bitcode, "test_single_clbit_variations_truthy")
@@ -63,7 +65,8 @@ def test_single_register_index_variations_truthy(value: bool) -> None:
     cr = ClassicalRegister(2, "creg")
     circuit.add_register(cr)
     circuit.measure(0, 0)
-    circuit.measure(1, 1).c_if(0, value)
+    with circuit.if_test((cr[0], value)):
+        circuit.measure(1, 1)
 
     generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
 
@@ -78,7 +81,8 @@ def test_single_register_index_variations_falsy(value: bool) -> None:
     cr = ClassicalRegister(2, "creg")
     circuit.add_register(cr)
     circuit.measure(0, 0)
-    circuit.measure(1, 1).c_if(0, value)
+    with circuit.if_test((cr[0], value)):
+        circuit.measure(1, 1)
 
     generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
 
@@ -93,7 +97,8 @@ def test_single_register_variations_truthy(value: bool) -> None:
     cr = ClassicalRegister(2, "creg")
     circuit.add_register(cr)
     circuit.measure(0, 0)
-    circuit.measure(1, 1).c_if(cr, value)
+    with circuit.if_test((cr, value)):
+        circuit.measure(1, 1)
 
     generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
 
@@ -106,13 +111,15 @@ def test_single_register_variations_falsy(value: bool) -> None:
     cr = ClassicalRegister(2, "creg")
     circuit.add_register(cr)
     circuit.measure(0, 0)
-    circuit.measure(1, 1).c_if(cr, value)
+    with circuit.if_test((cr, value)):
+        circuit.measure(1, 1)
 
     generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
 
     compare_reference_ir(generated_bitcode, "test_single_register_variations_falsy")
 
 
+@pytest.mark.skip(reason="Qiskit 2.0 removed c_if; if_test does not validate single-bit negative values")
 @pytest.mark.parametrize("value", invalid_single_bit_varitions)
 def test_single_clbit_invalid_variations(value: int) -> None:
     circuit = QuantumCircuit(2, 0, name=f"test_single_clbit_invalid_variations")
@@ -127,6 +134,7 @@ def test_single_clbit_invalid_variations(value: int) -> None:
     assert exc_info is not None
 
 
+@pytest.mark.skip(reason="Qiskit 2.0 removed c_if; if_test does not validate single-bit negative values")
 @pytest.mark.parametrize("value", invalid_single_bit_varitions)
 def test_single_register_index_invalid_variations(value: int) -> None:
     circuit = QuantumCircuit(
@@ -139,7 +147,8 @@ def test_single_register_index_invalid_variations(value: int) -> None:
     circuit.measure(0, 0)
 
     with pytest.raises(CircuitError) as exc_info:
-        _ = circuit.measure(1, 1).c_if(0, value)
+        with circuit.if_test((cr, value)):
+            circuit.measure(1, 1)
 
     assert exc_info is not None
 
@@ -151,8 +160,9 @@ def test_single_register_invalid_variations(value: int) -> None:
     circuit.add_register(cr)
     circuit.measure(0, 0)
 
-    with pytest.raises(CircuitError) as exc_info:
-        _ = circuit.measure(1, 1).c_if(cr, value)
+    with pytest.raises((CircuitError, TypeError)) as exc_info:
+        with circuit.if_test((cr, value)):
+            circuit.measure(1, 1)
 
     assert exc_info is not None
 
@@ -189,7 +199,8 @@ def test_two_bit_register_variations(matrix) -> None:
 
     circuit.measure(0, 0)
     circuit.measure(1, 1)
-    circuit.measure(2, 2).c_if(cr, value)
+    with circuit.if_test((cr, value)):
+        circuit.measure(2, 2)
 
     generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
 
@@ -212,7 +223,8 @@ def test_two_bit_register_invalid_variations(value: int) -> None:
     circuit.measure(0, 0)
     circuit.measure(1, 1)
 
-    with pytest.raises(CircuitError) as exc_info:
-        _ = circuit.measure(2, 2).c_if(cr, value)
+    with pytest.raises((CircuitError, TypeError)) as exc_info:
+        with circuit.if_test((cr, value)):
+            circuit.measure(2, 2)
 
     assert exc_info is not None

--- a/tests/test_c_if.py
+++ b/tests/test_c_if.py
@@ -119,24 +119,30 @@ def test_single_register_variations_falsy(value: bool) -> None:
     compare_reference_ir(generated_bitcode, "test_single_register_variations_falsy")
 
 
-@pytest.mark.skip(reason="Qiskit 2.0 removed c_if; if_test does not validate single-bit negative values")
+@pytest.mark.skip(
+    reason="Qiskit 2.0 removed c_if; if_test does not validate single-bit negative values — behavior no longer exists"
+)
 @pytest.mark.parametrize("value", invalid_single_bit_varitions)
 def test_single_clbit_invalid_variations(value: int) -> None:
+    # In Qiskit 1.x, c_if(bit, negative_value) raised CircuitError.
+    # In Qiskit 2.x, if_test() does not perform this validation.
     circuit = QuantumCircuit(2, 0, name=f"test_single_clbit_invalid_variations")
     cr = ClassicalRegister(2, "creg")
     circuit.add_register(cr)
     circuit.measure(0, 0)
     bit: Clbit = cr[0]
-
-    with pytest.raises(CircuitError) as exc_info:
-        _ = circuit.measure(1, 1).c_if(bit, value)
-
-    assert exc_info is not None
+    with circuit.if_test((bit, value)):
+        circuit.x(1)
+    # No exception expected in Qiskit 2.x
 
 
-@pytest.mark.skip(reason="Qiskit 2.0 removed c_if; if_test does not validate single-bit negative values")
+@pytest.mark.skip(
+    reason="Qiskit 2.0 does not validate register-index negative values in if_test — behavior no longer exists"
+)
 @pytest.mark.parametrize("value", invalid_single_bit_varitions)
 def test_single_register_index_invalid_variations(value: int) -> None:
+    # In Qiskit 1.x, c_if(register, negative_value) raised CircuitError.
+    # In Qiskit 2.x, if_test() does not perform this validation.
     circuit = QuantumCircuit(
         2,
         0,
@@ -145,12 +151,9 @@ def test_single_register_index_invalid_variations(value: int) -> None:
     cr = ClassicalRegister(2, "creg")
     circuit.add_register(cr)
     circuit.measure(0, 0)
-
-    with pytest.raises(CircuitError) as exc_info:
-        with circuit.if_test((cr, value)):
-            circuit.measure(1, 1)
-
-    assert exc_info is not None
+    with circuit.if_test((cr, value)):
+        circuit.x(1)
+    # No exception expected in Qiskit 2.x
 
 
 @pytest.mark.parametrize("value", invalid_single_bit_varitions)

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -125,46 +125,46 @@ def circuit_to_qir(circuit, profile: str = "AdaptiveExecution"):
     return visitor.ir()
 
 
-def test_branching_on_measurement_fails_without_required_capability():
+def test_branching_on_measurement_fails_teleport():
     circuit = teleport()
     with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
         _ = circuit_to_qir(circuit, "BasicExecution")
 
     exception_raised = exc_info.value
+    # In Qiskit 2.0, if_test() is expressed as IfElseOp
+    assert exception_raised.instruction.name == "if_else"
     assert (
-        str(exception_raised.instruction)
-        == "Instruction(name='x', num_qubits=1, num_clbits=0, params=[])"
+        str(exception_raised.instruction.condition)
+        == "(ClassicalRegister(2, 'cr'), 2)"
     )
+    assert str(exception_raised.qargs) == '[<Qubit register=(3, "qq"), index=2>]'
     assert (
-        str(exception_raised.instruction.condition) == "(ClassicalRegister(2, 'cr'), 2)"
+        str(exception_raised.cargs)
+        == '[<Clbit register=(2, "cr"), index=0>, <Clbit register=(2, "cr"), index=1>]'
     )
-    assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(3, 'qq'), 2)]"
-    assert str(exception_raised.cargs) == "[]"
     assert str(exception_raised.profile) == "BasicExecution"
-    assert exception_raised.instruction_string == "if(cr == 2) x qq[2]"
+    assert exception_raised.instruction_string == "if(cr == 2) if_else(param(cr[0]),param(cr[1])) qq[2]"
 
 
-def test_branching_on_measurement_fails_without_required_capability():
+def test_branching_on_measurement_fails_single_clbit_true():
     circuit = use_conditional_branch_on_single_register_true_value()
     with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
         _ = circuit_to_qir(circuit, "BasicExecution")
 
     exception_raised = exc_info.value
-    assert (
-        str(exception_raised.instruction)
-        == "Instruction(name='x', num_qubits=1, num_clbits=0, params=[])"
-    )
+    # In Qiskit 2.0, if_test() is expressed as IfElseOp
+    assert exception_raised.instruction.name == "if_else"
     assert (
         str(exception_raised.instruction.condition)
-        == "(Clbit(ClassicalRegister(3, 'creg'), 2), True)"
+        == '(<Clbit register=(3, "creg"), index=2>, 1)'
     )
-    assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(2, 'qreg'), 1)]"
-    assert str(exception_raised.cargs) == "[]"
+    assert str(exception_raised.qargs) == '[<Qubit register=(2, "qreg"), index=1>]'
+    assert str(exception_raised.cargs) == '[<Clbit register=(3, "creg"), index=2>]'
     assert str(exception_raised.profile) == "BasicExecution"
-    assert exception_raised.instruction_string == "if(creg[2] == True) x qreg[1]"
+    assert exception_raised.instruction_string == "if(creg[2] == 1) if_else(param(creg[2])) qreg[1]"
 
 
-def test_branching_on_measurement_fails_without_required_capability():
+def test_branching_on_measurement_fails_single_clbit_false():
     circuit = use_conditional_branch_on_single_register_false_value()
     with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
         _ = circuit_to_qir(circuit, "BasicExecution")

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -28,8 +28,10 @@ def teleport() -> QuantumCircuit:
     circuit.h(0)
     circuit.measure(0, 0)
     circuit.measure(1, 1)
-    circuit.x(2).c_if(cr, int("10", 2))
-    circuit.z(2).c_if(cr, int("01", 2))
+    with circuit.if_test((cr, int("10", 2))):
+        circuit.x(2)
+    with circuit.if_test((cr, int("01", 2))):
+        circuit.z(2)
     return circuit
 
 
@@ -67,7 +69,8 @@ def use_another_after_measure_and_condition():
     circuit.h(1)
     circuit.cx(1, 2)
     circuit.measure(1, 1)
-    circuit.x(2).c_if(cr, int("10", 2))
+    with circuit.if_test((cr, int("10", 2))):
+        circuit.x(2)
 
     return circuit
 
@@ -80,7 +83,8 @@ def use_conditional_branch_on_single_register_true_value():
     circuit.add_register(cr)
     circuit.x(0)
     circuit.measure(0, 0)
-    circuit.x(1).c_if(cr[2], 1)
+    with circuit.if_test((cr[2], 1)):
+        circuit.x(1)
     circuit.measure(0, 1)
 
     return circuit
@@ -94,7 +98,8 @@ def use_conditional_branch_on_single_register_false_value():
     circuit.add_register(cr)
     circuit.x(0)
     circuit.measure(0, 0)
-    circuit.x(1).c_if(cr[2], 0)
+    with circuit.if_test((cr[2], 0)):
+        circuit.x(1)
     circuit.measure(0, 1)
 
     return circuit
@@ -106,7 +111,8 @@ def conditional_branch_on_bit():
     circuit = QuantumCircuit(qr, cr, name="conditional_branch_on_bit")
     circuit.x(0)
     circuit.measure(0, 0)
-    circuit.x(1).c_if(cr[0], 1)
+    with circuit.if_test((cr[0], 1)):
+        circuit.x(1)
     circuit.measure(1, 1)
     return circuit
 
@@ -164,18 +170,16 @@ def test_branching_on_measurement_fails_without_required_capability():
         _ = circuit_to_qir(circuit, "BasicExecution")
 
     exception_raised = exc_info.value
-    assert (
-        str(exception_raised.instruction)
-        == "Instruction(name='x', num_qubits=1, num_clbits=0, params=[])"
-    )
+    # In Qiskit 2.0, c_if() is expressed as IfElseOp; the raised instruction is the IfElseOp
+    assert exception_raised.instruction.name == "if_else"
     assert (
         str(exception_raised.instruction.condition)
-        == "(Clbit(ClassicalRegister(3, 'creg'), 2), False)"
+        == '(<Clbit register=(3, "creg"), index=2>, 0)'
     )
-    assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(2, 'qreg'), 1)]"
-    assert str(exception_raised.cargs) == "[]"
+    assert str(exception_raised.qargs) == '[<Qubit register=(2, "qreg"), index=1>]'
+    assert str(exception_raised.cargs) == '[<Clbit register=(3, "creg"), index=2>]'
     assert str(exception_raised.profile) == "BasicExecution"
-    assert exception_raised.instruction_string == "if(creg[2] == False) x qreg[1]"
+    assert exception_raised.instruction_string == "if(creg[2] == 0) if_else(param(creg[2])) qreg[1]"
 
 
 def test_branching_on_measurement_register_passses_with_required_capability():
@@ -198,8 +202,8 @@ def test_reuse_after_measurement_fails_without_required_capability():
         str(exception_raised.instruction)
         == "Instruction(name='h', num_qubits=1, num_clbits=0, params=[])"
     )
-    assert exception_raised.instruction.condition is None
-    assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(2, 'qq'), 1)]"
+    assert getattr(exception_raised.instruction, "condition", None) is None
+    assert str(exception_raised.qargs) == '[<Qubit register=(2, "qq"), index=1>]'
     assert str(exception_raised.cargs) == "[]"
     assert str(exception_raised.profile) == "BasicExecution"
     assert exception_raised.instruction_string == "h qq[1]"

--- a/tests/test_circuits/basic_circuits.py
+++ b/tests/test_circuits/basic_circuits.py
@@ -31,8 +31,10 @@ def teleport():
     circuit.h(0)
     circuit.measure(0, 0)
     circuit.measure(1, 1)
-    circuit.x(2).c_if(cr, int("10", 2))
-    circuit.z(2).c_if(cr, int("01", 2))
+    with circuit.if_test((cr, int("10", 2))):
+        circuit.x(2)
+    with circuit.if_test((cr, int("01", 2))):
+        circuit.z(2)
 
     return circuit
 
@@ -60,8 +62,10 @@ def teleport_with_subroutine():
     circuit.h(0)
     circuit.measure(0, 0)
     circuit.measure(1, 1)
-    circuit.x(2).c_if(cr, int("10", 2))
-    circuit.z(2).c_if(cr, int("01", 2))
+    with circuit.if_test((cr, int("10", 2))):
+        circuit.x(2)
+    with circuit.if_test((cr, int("01", 2))):
+        circuit.z(2)
 
     return circuit
 

--- a/tests/test_circuits/random.py
+++ b/tests/test_circuits/random.py
@@ -6,14 +6,22 @@ import pytest
 
 from qiskit import transpile
 from qiskit.circuit.random import random_circuit
-from qiskit_qir.visitor import SUPPORTED_INSTRUCTIONS
+
+# Standard Qiskit basis gates that overlap with supported instructions.
+# Non-standard gates (m, measure_x, initialize, barrier, delay) are excluded
+# because Qiskit 2.0 transpile() does not accept non-standard basis_gates.
+_TRANSPILE_BASIS_GATES = [
+    "measure", "cx", "cz", "h", "reset",
+    "rx", "ry", "rz", "s", "sdg", "t", "tdg",
+    "x", "y", "z", "id",
+]
 
 
 def _generate_random_fixture(num_qubits, depth):
     @pytest.fixture()
     def random():
         circuit = random_circuit(num_qubits, depth, measure=True)
-        return transpile(circuit, basis_gates=SUPPORTED_INSTRUCTIONS)
+        return transpile(circuit, basis_gates=_TRANSPILE_BASIS_GATES)
 
     return random
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -74,7 +74,8 @@ def test_branching_on_bit_emits_correct_ir():
     circuit = QuantumCircuit(qr, cr, name="branching_on_bit_emits_correct_ir")
     circuit.x(0)
     circuit.measure(0, 0)
-    circuit.x(0).c_if(cr[0], 1)
+    with circuit.if_test((cr[0], 1)):
+        circuit.x(0)
 
     ir = str(to_qir_module(circuit)[0])
     generated_qir = ir.splitlines()
@@ -119,7 +120,8 @@ def test_branching_on_register_with_one_bit_emits_correct_ir():
     )
     circuit.x(0)
     circuit.measure(0, 0)
-    circuit.x(0).c_if(cr, 1)
+    with circuit.if_test((cr, 1)):
+        circuit.x(0)
 
     ir = str(to_qir_module(circuit)[0])
     generated_qir = ir.splitlines()

--- a/tests/test_qiskit_qir.py
+++ b/tests/test_qiskit_qir.py
@@ -33,6 +33,31 @@ if _log.isEnabledFor(logging.DEBUG) and not _test_output_dir.exists():
     _test_output_dir.mkdir()
 
 
+def test_if_test_with_expr_api_raises_not_implemented():
+    """expr.Expr conditions must raise NotImplementedError, not a cryptic TypeError."""
+    from qiskit.circuit.classical import expr as qiskit_expr
+
+    circuit = QuantumCircuit(2, 2)
+    circuit.measure(0, 0)
+    cr = circuit.cregs[0]
+    with circuit.if_test(qiskit_expr.equal(cr, 1)):
+        circuit.x(1)
+    with pytest.raises(NotImplementedError, match="Classical expression conditions"):
+        to_qir_module(circuit)
+
+
+def test_if_else_with_else_branch_raises_not_implemented():
+    """if-else circuits (with else body) must raise NotImplementedError, not silently drop the else."""
+    circuit = QuantumCircuit(2, 2)
+    circuit.measure(0, 0)
+    with circuit.if_test((circuit.clbits[0], 0)) as else_:
+        circuit.x(1)
+    with else_:
+        circuit.h(1)
+    with pytest.raises(NotImplementedError, match="else branch"):
+        to_qir_module(circuit)
+
+
 @pytest.mark.parametrize("circuit_name", core_tests)
 def test_visitor(circuit_name, request):
     circuit = request.getfixturevalue(circuit_name)

--- a/tests/test_qiskit_qir.py
+++ b/tests/test_qiskit_qir.py
@@ -97,7 +97,10 @@ def test_noop_gates(circuit_name, request):
     assert generated_ir is not None
 
 
-@pytest.mark.xfail(Reason="OpenQASM 3.0-style control flow is not supported yet")
+@pytest.mark.xfail(
+    reason="OpenQASM 3.0-style control flow is not supported yet",
+    strict=True,
+)
 @pytest.mark.parametrize("circuit_name", cf_fixtures)
 def test_control_flow(circuit_name, request):
     circuit = request.getfixturevalue(circuit_name)

--- a/tests/test_qiskit_qir.py
+++ b/tests/test_qiskit_qir.py
@@ -50,8 +50,6 @@ def test_to_qir_string(circuit_name, request):
     generated_ir = str(to_qir_module(circuit)[0])
     assert generated_ir is not None
     if _log.isEnabledFor(logging.DEBUG):
-        qasm_path = _test_output_dir.joinpath(circuit_name + ".qasm")
-        circuit.qasm(filename=str(qasm_path))
         qir_path = _test_output_dir.joinpath(circuit_name + ".ll")
         qir_path.write_text(generated_ir)
 
@@ -81,8 +79,6 @@ def test_control_flow(circuit_name, request):
     generated_ir = str(to_qir_module(circuit)[0])
     assert generated_ir is not None
     if _log.isEnabledFor(logging.DEBUG):
-        qasm_path = _test_output_dir.joinpath(circuit_name + ".qasm")
-        circuit.qasm(filename=str(qasm_path))
         qir_path = _test_output_dir.joinpath(circuit_name + ".ll")
         qir_path.write_text(generated_ir)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,20 +9,20 @@ from pyqir import is_entry_point, Context, Module, Function
 
 def _qubit_string(qubit: int) -> str:
     if qubit == 0:
-        return "%Qubit* null"
+        return "ptr null"
     else:
-        return f"%Qubit* inttoptr (i64 {qubit} to %Qubit*)"
+        return f"ptr inttoptr (i64 {qubit} to ptr)"
 
 
 def _result_string(res: int) -> str:
     if res == 0:
-        return "%Result* null"
+        return "ptr null"
     else:
-        return f"%Result* inttoptr (i64 {res} to %Result*)"
+        return f"ptr inttoptr (i64 {res} to ptr)"
 
 
 def initialize_call_string() -> str:
-    return "call void @__quantum__rt__initialize(i8* null)"
+    return "call void @__quantum__rt__initialize(ptr null)"
 
 
 def single_op_call_string(name: str, qb: int) -> str:
@@ -64,12 +64,12 @@ def return_string() -> str:
 
 def array_record_output_string(num_elements: int) -> str:
     return (
-        f"call void @__quantum__rt__array_record_output(i64 {num_elements}, i8* null)"
+        f"call void @__quantum__rt__array_record_output(i64 {num_elements}, ptr null)"
     )
 
 
 def result_record_output_string(res: str) -> str:
-    return f"call void @__quantum__rt__result_record_output({_result_string(res)}, i8* null)"
+    return f"call void @__quantum__rt__result_record_output({_result_string(res)}, ptr null)"
 
 
 # Returns the method body with:

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
-envlist = py38, py39, py310, py311, py312, black
+envlist = py310, py311, py312, black
 
 [travis]
 python =
     3.12: py312
     3.11: py311
     3.10: py310
-    3.9: py39
-    3.8: py38
 
 [testenv:black]
 basepython = python


### PR DESCRIPTION
**Branch:** `feat/qiskit-2-migration`  
**Base:** `main`  
**Commits:** 8 (4 migration + 4 review fixes)  
**Test result:** 348 passed, 2 skipped, 3 xfailed, 0 failures  

---

## What this MR does in one sentence

Migrates `qiskit-qir-alice-bob-fork` from Qiskit 1.x + pyqir 0.10 to Qiskit 2.0 + pyqir 0.12, replacing the removed `c_if()` gate conditioning mechanism with `IfElseOp` handling and updating all IR output for the new opaque pointer format.

---

## Why this is non-trivial

Qiskit 2.0 made three breaking changes that affect this library's core translation loop:

1. **`instruction.condition` was removed from standard gates.** In Qiskit 1.x, you could attach a classical condition to any gate via `.c_if()`, and read it back via `instruction.condition`. In Qiskit 2.0, this attribute no longer exists on standard gates — conditioning is expressed exclusively through `IfElseOp` wrapper instructions in the circuit DAG.

2. **`circuit._data` became a typed public API.** The private `circuit._data` loop returned `(instruction, qargs, cargs)` tuples. In Qiskit 2.0, `circuit.data` returns `list[CircuitInstruction]`, where each item has `.operation`, `.qubits`, `.clbits`.

3. **pyqir 0.12 uses opaque pointers.** All typed LLVM pointer types (`%Qubit*`, `%Result*`, `i8*`) became opaque `ptr`. The functions `qubit_type()`, `result_type()`, and `qubit_id()` were removed or renamed.

---

## Commit-by-commit walkthrough

### 1. `chore: bump to qiskit>=2.0,<3.0 and pyqir>=0.12,<0.13, drop Python 3.8/3.9`

**Files:** `setup.cfg`, `requirements_dev.txt`, `tox.ini`

Straightforward version bumps. Python 3.8/3.9 dropped because Qiskit 2.0 requires 3.10+.

> **What to check:** The version range `pyqir>=0.12.0,<0.13` is intentionally tight — pyqir has had breaking API changes in every minor release.

---

### 2. `fix: update imports for Qiskit 2.0 and pyqir 0.12 API changes`

**Files:** `src/qiskit_qir/elements.py`, `src/qiskit_qir/visitor.py`

**Import fixes:**
- `from qiskit.circuit.bit import Bit` → `from qiskit.circuit import Bit` (submodule removed)
- `qubit_id` → `ptr_id` (renamed in pyqir 0.12)

**`elements.py` — circuit._data → circuit.data:**
```python
# Before (Qiskit 1.x)
for instruction, qargs, cargs in circuit._data:
    elements.append(_Instruction(instruction, qargs, cargs))

# After (Qiskit 2.x)
for circuit_instruction in circuit.data:
    elements.append(_Instruction(
        circuit_instruction.operation,
        list(circuit_instruction.qubits),
        list(circuit_instruction.clbits),
    ))
```
The `list()` calls are necessary because `.qubits`/`.clbits` on `CircuitInstruction` are tuples, and the rest of the code expects lists.

> **What to check:** `elements.py` has two loops — `_data` was in `QiskitModule.from_quantum_circuit`. Make sure both are updated (check `process_composite_instruction` in visitor.py too — see commit 3).

---

### 3. `fix(visitor): update process_composite_instruction to Qiskit 2.0 CircuitInstruction API`

**Files:** `src/qiskit_qir/visitor.py`, `tests/test_circuits/basic_circuits.py`

**The subcircuit loop in `process_composite_instruction`** had the same `(inst, qargs, cargs)` unpacking:
```python
# Before
for inst, i_qargs, i_cargs in subcircuit.data:

# After  
for circuit_instr in subcircuit.data:
    inst = circuit_instr.operation
    i_qargs = circuit_instr.qubits
    i_cargs = circuit_instr.clbits
```

**`basic_circuits.py` fixtures:** `teleport` and `teleport_with_subroutine` used `c_if()` — converted to `if_test` context managers. These are shared fixtures used by integration tests.

---

### 4. `fix: complete Qiskit 2.0 + pyqir 0.12 migration`

This is the largest commit. It covers:

#### 4a. `visitor.py` — the core `IfElseOp` handler

This is the most important change. The old `visit_instruction` had a block that read `instruction.condition` to decide whether to wrap the gate in a `qis.if_result` call:

```python
# OLD — Qiskit 1.x approach (no longer works)
if instruction.condition is not None and not skip_condition:
    # ... build the if_result wrapper ...
    # ... then recursively call visit_instruction(..., skip_condition=True) ...
```

In Qiskit 2.0, conditioning is expressed as a separate `IfElseOp` node in the circuit. The gate (`x`, `measure`, etc.) appears *inside* `IfElseOp.blocks[0]` with no condition of its own.

**New approach:**
```python
def visit_instruction(self, instruction, qargs, cargs):
    if isinstance(instruction, IfElseOp):       # NEW: dispatch to handler
        self._visit_if_else_op(instruction, qargs, cargs)
        return
    # ... rest handles plain gates with no condition ...
```

The new `_visit_if_else_op` method:
1. Checks capability (raises `ConditionalBranchingOnResultError` if needed)
2. Guards against unsupported else-branch (`len(op.blocks) > 1`)
3. Guards against `expr.Expr` conditions (new Qiskit 2.x API, not yet supported)
4. Reads condition as a `(Clbit_or_ClassicalRegister, value)` tuple
5. Builds the recursive `qis.if_result` branch structure (same logic as before, just moved here)
6. Visits the true body `op.blocks[0]` by iterating its `.data`

**Key insight confirmed by testing:** In Qiskit 2.4.1, `IfElseOp.condition` is still a plain tuple — NOT a `qiskit.circuit.classical.expr.Expr` object (which is what the new `expr` API produces). The tuple-based condition and the expr-based condition are two parallel mechanisms.

**Body qubit mapping:** The body circuit `op.blocks[0]` references the *same Qubit objects* as the parent circuit's qargs. No remapping dictionary is needed — the `_qubit_labels` dict (keyed by Qubit object identity) resolves them correctly because Qiskit uses value-based equality for `Qubit` objects.

#### 4b. `visitor.py` — pyqir 0.12 type function replacements

Three declare functions used the removed `pyqir.qubit_type(ctx)` and `pyqir.result_type(ctx)`:
```python
# Before
pyqir.qubit_type(mod.context)     # removed in 0.12
pyqir.result_type(mod.context)    # removed in 0.12

# After — opaque pointer = i8*
PointerType(IntType(mod.context, 8))
```

> **Why `i8*`?** In LLVM's opaque pointer model, all pointers are `ptr`. The `PointerType(IntType(ctx, 8))` is pyqir 0.12's way to construct a `ptr` type. The `8` (i.e. `i8`) does not affect the actual type — it's just the required argument to `PointerType`.

#### 4c. `capability.py` — `instruction.condition` removal

In `_get_instruction_string`, the condition check was `instruction.condition is not None`. Standard gates in Qiskit 2.0 don't have `.condition` at all, so this would `AttributeError`. Fixed with `getattr`:
```python
condition = getattr(instruction, "condition", None)
```
Also fixed `register._name` → `register.name` (private attribute removed).

#### 4d. Golden `.ll` files (10 files in `tests/resources/`)

The pyqir 0.12 IR output format changed:
- Removed: `%Qubit = type opaque` and `%Result = type opaque` declarations at top
- Changed: All `%Qubit*`, `%Result*`, `i8*` → `ptr`
- Changed: `%Qubit* null` → `ptr null`
- Changed: `%Qubit* inttoptr (i64 1 to %Qubit*)` → `ptr inttoptr (i64 1 to ptr)`

These files are binary-compared against actual compiler output in `test_c_if.py`. If they're wrong, the test fails loudly — so their correctness is verified by the test suite.

#### 4e. `test_utils.py` — helper string constants

The string templates used in non-golden tests (like `test_output.py`, `test_qiskit_qir.py`) were updated:
- `_qubit_string()`: `%Qubit* null` → `ptr null`, `%Qubit* inttoptr...` → `ptr inttoptr...`
- `_result_string()`: same pattern
- `initialize_call_string()`: `i8* null` → `ptr null`
- `array_record_output_string()` / `result_record_output_string()`: `i8* null` → `ptr null`

#### 4f. `test_c_if.py` — `c_if()` → `if_test`

All golden-file tests were using the removed `c_if()`. The conversion:
```python
# Before
circuit.measure(1, 1).c_if(bit, value)

# After
with circuit.if_test((bit, value)):
    circuit.measure(1, 1)
```
The circuit semantics are identical — this just uses the new API to express the same operation. Verified by the golden files: same QIR output.

Two tests (`test_single_clbit_invalid_variations`, `test_single_register_index_invalid_variations`) are **skipped** because they tested that Qiskit 1.x raised `CircuitError` for negative conditioning values. Qiskit 2.x does not perform this validation.

One test (`test_single_register_invalid_variations`) was updated to accept `(CircuitError, TypeError)` — Qiskit 2.x may raise either depending on the value.

#### 4g. `tests/test_circuits/random.py` — `transpile` basis gates

In Qiskit 2.0, `transpile(basis_gates=[...])` validates that all gates in the list are known standard gates. The old code passed `SUPPORTED_INSTRUCTIONS` which includes `"m"` (a custom Alice-Bob gate). Fixed by using only standard basis gates for transpilation.

---

### 5. `fix(visitor): guard against expr.Expr conditions and else-branch in IfElseOp`

Two correctness fixes after code review:

**Else-branch guard:**
```python
if len(op.blocks) > 1:
    raise NotImplementedError(
        "IfElseOp with an else branch is not yet supported. ..."
    )
```
Before this fix, `op.blocks[1]` (the else body) was silently dropped — no error, no warning, wrong QIR. This is now an explicit `NotImplementedError` with a clear message.

**expr.Expr guard:**
```python
if not isinstance(op.condition, tuple):
    raise NotImplementedError(
        "Classical expression conditions (expr API) are not yet supported. ..."
    )
```
In Qiskit 2.x, `circuit.if_test(expr.equal(cr, 3))` produces an `IfElseOp` whose `.condition` is a `Binary` expression object. Without this guard, unpacking `op.condition` throws `TypeError: cannot unpack non-iterable Binary`. Now it raises `NotImplementedError` with a message pointing to the tuple-based API.

---

### 6-8. Test quality fixes (commits 6, 7, 8)

**xfail metadata fix (`test_qiskit_qir.py`):**  
`@pytest.mark.xfail(Reason=...)` — note capital `R`. pytest silently ignores unknown kwargs, so the reason string was never stored and XPASS was never an error. Fixed to `reason=` (lowercase) + `strict=True`.

**Duplicate test functions (`test_capabilities.py`):**  
Three functions had the identical name `test_branching_on_measurement_fails_without_required_capability`. Python silently kept only the last definition — two test scenarios (teleport circuit and single-clbit-true) were never executed. Renamed to unique names and updated their Qiskit 1.x assertion strings to Qiskit 2.x repr format.

**Stale `c_if()` in skipped tests (`test_c_if.py`):**  
Two skipped tests still called `c_if()` in their bodies. If un-skipped, they'd fail with `AttributeError` instead of the expected behavior. Updated to `if_test()` with comments explaining the removed validation.

---

## Known limitations (not fixed in this MR)

### 1. `if-else` (IfElseOp with else branch) is not supported
Any circuit using `with circuit.if_test(...) as else_: ... with else_: ...` will raise `NotImplementedError`. This is guarded explicitly. Support for else branches requires rearchitecting the `_branch` recursive closure in `_visit_if_else_op` to thread a false-body callback alongside the true-body one.

### 2. `expr.Expr` conditions are not supported
The new Qiskit 2.x `circuit.if_test(expr.equal(cr, 3))` API is not supported. The old tuple-based `circuit.if_test((cr, 3))` API works. Guarded explicitly with a `NotImplementedError`.

### 3. `while_loop` and `for_loop` remain unsupported
These were unsupported before and remain so. They are correctly xfailed with `strict=True`.

---

## Things to pay special attention to

### `_visit_if_else_op` — the `_branch` closure (visitor.py ~line 375)

This is the trickiest piece of code. It builds a nested `qis.if_result` structure by recursing over the bit-condition pairs:

```python
def _branch(conditions_values):
    try:
        cond, val = next(conditions_values)
        def __branch():
            qis.if_result(
                self._builder, cond,
                one=_branch(conditions_values) if val == "1" else None,
                zero=_branch(conditions_values) if val == "0" else None,
            )
    except StopIteration:
        return __visit_body
    else:
        return __branch

_branch(zip(conditions, values[::-1]))()
```

The key design points:
- `conditions_values` is a **stateful iterator** — `next()` advances it permanently. Each recursive call to `_branch` consumes the next condition bit.
- `values[::-1]` — Qiskit stores the MSB on the right side of the bit string (little-endian bit order), so reversal is needed before iterating.
- `one=...` vs `zero=...` — the true body executes on the path where the bit equals the expected value. If `val == "1"`, the true body is on `one=` (bit is 1); otherwise on `zero=` (bit is 0). The other path is `None` (no-op).
- When the iterator is exhausted (`StopIteration`), return `__visit_body` — the leaf callback that actually emits the gates.

This logic is **unchanged from Qiskit 1.x** — it was just moved from `visit_instruction` into `_visit_if_else_op`.

### Body qubit resolution

When visiting `true_body.data`, the qubits in `circuit_instr.qubits` are resolved against `self._qubit_labels`. The claim is that body qubits are the *same objects* as the parent circuit's qargs. This is true in Qiskit 2.4.1 for circuits constructed with `if_test()` — but it's worth verifying if this changes in future Qiskit versions or for circuits constructed through transpilation.

### `capability.py` — what instruction gets passed to errors

When `_visit_if_else_op` raises `ConditionalBranchingOnResultError`, it passes the `IfElseOp` itself (not the inner gate) as the `instruction`. This means:
- `error.instruction.name` is `"if_else"`, not `"x"` or `"measure"`
- `error.instruction_string` includes `param(...)` for the cargs of the IfElseOp
- The test assertions in `test_capabilities.py` reflect this

This is a behavior change from Qiskit 1.x where the inner gate (e.g., `x`) was the reported instruction. The new behavior is arguably better — it reports the actual circuit construct the user wrote.

---

## Test coverage summary

| Scenario | Coverage | Test file |
|----------|----------|-----------|
| Single Clbit condition (true/false) | ✅ Golden file | `test_c_if.py` |
| ClassicalRegister condition (1-bit, 2-bit) | ✅ Golden file | `test_c_if.py` |
| Teleport (register condition on 2-bit cr) | ✅ Capability + integration | `test_capabilities.py`, `basic_circuits.py` |
| `BasicExecution` profile raises error | ✅ 3 renamed tests | `test_capabilities.py` |
| `AdaptiveExecution` profile passes | ✅ Pass tests | `test_capabilities.py` |
| Else branch raises NotImplementedError | ✅ New test | `test_qiskit_qir.py` |
| `expr.Expr` condition raises NotImplementedError | ✅ New test | `test_qiskit_qir.py` |
| `while_loop`, `for_loop`, `if_else` xfail | ✅ Strict xfail | `test_qiskit_qir.py` |
| Negative conditioning values (Qiskit 1.x only) | ⏭️ Skipped | `test_c_if.py` |
| Else branch full implementation | ❌ Not implemented | — |
| `expr.Expr` full implementation | ❌ Not implemented | — |

---

## How to navigate the diff

Suggested review order:

1. **`setup.cfg` + `tox.ini` + `requirements_dev.txt`** — version bumps only, 5 min
2. **`src/qiskit_qir/elements.py`** — small, the `circuit._data` → `circuit.data` fix
3. **`src/qiskit_qir/capability.py`** — `getattr` guard + `register._name` → `register.name`
4. **`src/qiskit_qir/visitor.py`** — the meat; focus on:
   - Lines ~10-30: imports
   - Lines ~205-215: `process_composite_instruction` loop fix
   - Lines ~222-260: `visit_instruction` — how the old condition block was removed
   - Lines ~331-400: the new `_visit_if_else_op` method (read the `_branch` section carefully)
   - Lines ~428-455: `_declare_*` functions with `PointerType(IntType(..., 8))`
5. **`tests/resources/*.ll`** — skim one file to understand the pointer format change; all 10 follow the same pattern
6. **`tests/test_utils.py`** — string constants for non-golden tests
7. **`tests/test_c_if.py`** — `c_if` → `if_test` conversions + skip rationale
8. **`tests/test_circuits/basic_circuits.py`** + **`tests/test_circuits/random.py`** — fixture updates
9. **`tests/test_output.py`** + **`tests/test_capabilities.py`** — more `c_if` → `if_test`, renamed test functions
10. **`tests/test_qiskit_qir.py`** — new guard tests + xfail fix

---

## Questions for reviewers

1. **Body qubit mapping:** Is there any scenario in Alice-Bob's use cases where `IfElseOp` body qubits would *not* be the same objects as the parent circuit's qargs? (e.g., after certain transpiler passes)

2. **Else branch priority:** How urgently is else-branch support needed? The guard converts what was a silent correctness bug into an explicit error. But if Alice-Bob circuits use `if-else` patterns, this MR would be a regression on that functionality.

3. **`expr.Expr` timeline:** Same question — are any circuits currently using `expr.equal(cr, n)` style conditions? If so, this MR breaks them (with an explicit error, but still broken).

4. **The `PointerType(IntType(ctx, 8))` idiom:** Is there a more semantically correct way to express an opaque `ptr` type in pyqir 0.12? The `i8` argument feels like a hack, but this is what pyqir 0.12's API requires.

---

## Hard parts: where this migration required careful thought

This section documents the places where the migration was genuinely difficult — either because the answer was non-obvious, required empirical verification, or had hidden traps. Useful both for understanding why certain choices were made and for future maintainers who re-visit these areas.

---

### 1. `IfElseOp.condition` format: tuple or `expr.Expr`?

**Why it was hard:** The Qiskit 2.0 changelog and several GitHub discussions suggest that `IfElseOp.condition` may return an `expr.Expr` object rather than a tuple. The [Qiskit 0.24 release notes](https://docs.quantum.ibm.com/api/qiskit/release-notes/0.24) introduce the `classical.expr` subsystem, and the [migration guide](https://docs.quantum.ibm.com/migration-guides/qiskit-1.0-features) warns that `c_if()` is deprecated in favour of `expr`. It was not clear from documentation alone which format Qiskit 2.4.1 would use for circuits built with `circuit.if_test((clbit, value))`.

**What we found:** In Qiskit 2.4.1, `if_test((clbit_or_register, value))` still produces an `IfElseOp` with a plain tuple `condition`. The `expr.Expr` format only appears when using the explicit `expr` API (`circuit.if_test(expr.equal(cr, 3))`). These are two parallel mechanisms. This was confirmed empirically:

```python
circuit.if_test((cr[2], 0))      # → IfElseOp.condition = (Clbit(...), 0)   ← tuple
circuit.if_test(expr.equal(cr, 3)) # → IfElseOp.condition = Binary(...)      ← expr.Expr
```

**Risk:** This may change in a future Qiskit release. The `expr` guard added in commit 5 ensures that if the format changes, we get a `NotImplementedError` rather than a silent wrong output.

**References:**
- [Qiskit `classical.expr` documentation](https://docs.quantum.ibm.com/api/qiskit/circuit_classical)
- [IfElseOp API reference](https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.IfElseOp)
- [Qiskit 1.0 migration guide — conditions](https://docs.quantum.ibm.com/migration-guides/qiskit-1.0-features#condition)

---

### 2. Body qubit mapping in `IfElseOp.blocks[0]`

**Why it was hard:** When visiting the body of an `if_test` block, the body circuit (`op.blocks[0]`) contains its own qubit objects. The question was: are these the *same Python objects* as the parent circuit's qargs, or are they *copies* that need to be remapped through a separate index?

If they were copies, the `_qubit_labels` dict (keyed by qubit object) would silently return `None` for every body qubit — the gate would be emitted to qubit `None`, which pyqir would likely mishandle. This would be a silent bug.

**What we found:** In Qiskit 2.4.1, for circuits built with `circuit.if_test()`, the body circuit shares the *same Qubit objects* (by identity) with the parent. `_qubit_labels[body_qubit]` resolves correctly. This was verified with:

```python
parent_qubit = circuit.qubits[1]
body_qubit = op.blocks[0].qubits[0]
assert parent_qubit is body_qubit  # True in Qiskit 2.4.1
```

**Risk:** This identity guarantee may not hold after certain transpiler passes, or in future Qiskit versions. If it breaks, all conditionally-executed gates would silently target qubit 0 (because `dict.get(key)` returns `None` for unknown keys, and `pyqir.qubit(ctx, None)` would likely default to 0).

**How to detect if this breaks:** Add a defensive check in `_visit_if_else_op` before the body loop:
```python
for i, body_qubit in enumerate(true_body.qubits):
    assert body_qubit in self._qubit_labels, f"Body qubit {i} not found in parent labels"
```

**References:**
- [Qiskit `IfElseOp` source](https://github.com/Qiskit/qiskit/blob/main/qiskit/circuit/controlflow/if_else.py)

---

### 3. The `_branch` recursive closure and stateful iterator

**Why it was hard:** This code uses a pattern that is easy to misread: a recursive function that closes over a *shared, mutable iterator*. Each call to `next(conditions_values)` permanently advances the iterator — subsequent recursive calls see the next bit, not the same bit.

```python
def _branch(conditions_values):          # conditions_values is a shared zip iterator
    try:
        cond, val = next(conditions_values)   # consumes one item permanently
        def __branch():
            qis.if_result(
                self._builder, cond,
                one=_branch(conditions_values) if val == "1" else None,
                zero=_branch(conditions_values) if val == "0" else None,
            )
    except StopIteration:
        return __visit_body              # base case: emit the gates
    else:
        return __branch                  # return a callable, not call it yet
```

The subtlety: `_branch()` returns a *callable* (`__branch`), not the result of calling `__branch`. The caller then invokes it: `_branch(...)()`. This deferred execution is what makes the nesting work correctly.

For a single-clbit condition `(cr[0], 1)`:
- `conditions = [result_0]`, `values = "1"` → reversed = `"1"`
- `_branch(zip([result_0], "1"))` → cond=result_0, val="1"
- Returns `__branch` which calls `qis.if_result(builder, result_0, one=_branch(...), zero=None)`
- `_branch(...)` hits `StopIteration` → returns `__visit_body`
- Final structure: `if result_0 == 1: visit_body()`

For a 2-bit register condition `(cr, 2)` (binary `10`):
- `values = "10"` → reversed = `"01"` → bits are `"0"`, `"1"` (LSB first)
- First bit: val="0", so `zero=_branch(next)`, `one=None`
- Second bit: val="1", so `one=__visit_body`, `zero=None`
- Structure: `if result_0==0: if result_1==1: visit_body()`

**References:**
- [pyqir `if_result` documentation](https://qir-alliance.github.io/pyqir/api/pyqir.qis.html)
- [QIR branching spec](https://github.com/qir-alliance/qir-spec)

---

### 4. pyqir 0.12: replacing `qubit_type()` and `result_type()`

**Why it was hard:** pyqir 0.12 removed `pyqir.qubit_type(ctx)` and `pyqir.result_type(ctx)` with no direct equivalent in the changelog. The [pyqir 0.12 release notes](https://github.com/qir-alliance/pyqir/releases/tag/v0.12.0) describe the switch to LLVM opaque pointers but don't spell out the replacement recipe.

**What we found:** In LLVM's opaque pointer model (`-opaque-pointers`), all pointer types are simply `ptr`. In pyqir 0.12's Python API, a `ptr` type is created via:
```python
PointerType(IntType(context, 8))
```
The `IntType(ctx, 8)` is the pointee type hint — in opaque pointer mode it is ignored by LLVM, but pyqir's `PointerType` constructor still requires it. The value `8` (i.e. `i8`) is conventional; `IntType(ctx, 1)` would work equally well for the actual generated IR.

**Reference:**
- [LLVM opaque pointer migration guide](https://llvm.org/docs/OpaquePointers.html)
- [pyqir 0.12 release notes](https://github.com/qir-alliance/pyqir/releases/tag/v0.12.0)
- [pyqir `PointerType` API](https://qir-alliance.github.io/pyqir/api/pyqir.html#pyqir.PointerType)

---

### 5. `transpile(basis_gates=...)` rejecting non-standard gates

**Why it was hard:** In `tests/test_circuits/random.py`, the code called:
```python
transpile(circuit, basis_gates=SUPPORTED_INSTRUCTIONS)
```
`SUPPORTED_INSTRUCTIONS` includes `"m"` — a custom Alice-Bob measurement gate. In Qiskit 1.x, `transpile` accepted unknown gate names in `basis_gates` silently. In Qiskit 2.0, it validates the list and raises an error for non-standard gate names.

This failure only appears when running the random circuit test, not in any of the core tests, so it was easy to miss during initial porting.

**Fix:** Use a separate constant `_TRANSPILE_BASIS_GATES` containing only standard Qiskit gate names, keeping `SUPPORTED_INSTRUCTIONS` (with `"m"`) for the visitor's gate dispatch logic.

**Reference:**
- [Qiskit 2.0 `transpile` API changes](https://docs.quantum.ibm.com/migration-guides/qiskit-2.0)

---

### 6. The `expr.Expr` test — wrong API on first attempt

**Why it was hard:** Constructing an `expr.Expr` condition for the test required knowing the correct pyqir `expr` builder API. The first attempt:
```python
qiskit_expr.equal(qiskit_expr.lift(cr), qiskit_expr.lift(1, cr.size))
```
Failed with `AttributeError: 'int' object has no attribute 'kind'` because `qiskit_expr.lift(1, cr.size)` expects a `Type` object as the second argument, not an integer width.

The correct API is simply:
```python
qiskit_expr.equal(cr, 1)
```
Qiskit's `expr.equal()` accepts a `ClassicalRegister` directly and infers the type.

**Reference:**
- [Qiskit `circuit.classical.expr` builder functions](https://docs.quantum.ibm.com/api/qiskit/circuit_classical#expression-construction)

---

### 7. The silent else-branch bug — hard to notice without running the right test

**Why it was hard:** The `_visit_if_else_op` implementation only processed `op.blocks[0]`. The else body in `op.blocks[1]` was ignored without any error. This was undetectable from the test suite because:

1. The `if_else` fixture in `test_control_flow` *did* have an else branch, but the assertion was only `assert generated_ir is not None` — not verifying content.
2. The test was marked `xfail` (with wrong kwargs, so XPASS was silently tolerated).
3. All other test circuits used if-without-else.

The bug was only caught by running a custom empirical check during code review:
```python
h_in_ir = "__quantum__qis__h__body" in generated_ir
# h_in_ir was False — the else body (h gate) was dropped
```

**Lesson for future work:** When adding support for new circuit constructs, add a content-verifying test (like the golden file tests), not just an existence check.

---

### 8. Three test functions with the same name — Python silently keeps only the last

**Why it was hard:** In `test_capabilities.py`, three functions were defined with the identical name `test_branching_on_measurement_fails_without_required_capability`. Python's module namespace simply overwrites the earlier definitions. pytest collects by scanning the module's `__dict__`, so it only sees the last definition.

The first two functions had stale Qiskit 1.x assertion strings (checking for `"Instruction(name='x', ...)"` and `instruction.condition`). Because they never ran, these failures were invisible. When the tests were finally renamed and made active, they exposed an additional bug: `register._name` in `capability.py` (another private attribute removed in Qiskit 2.0), which only affects the register-condition code path exercised by the `teleport` circuit.

**References:**
- No external references; this is a plain Python scoping rule.

---

## External reference index

| Topic | URL |
|-------|-----|
| Qiskit 2.0 migration guide | https://docs.quantum.ibm.com/migration-guides/qiskit-2.0 |
| Qiskit 1.0 `c_if` deprecation | https://docs.quantum.ibm.com/migration-guides/qiskit-1.0-features#condition |
| Qiskit `circuit.classical.expr` | https://docs.quantum.ibm.com/api/qiskit/circuit_classical |
| `IfElseOp` API reference | https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.IfElseOp |
| pyqir 0.12 release notes | https://github.com/qir-alliance/pyqir/releases/tag/v0.12.0 |
| pyqir `PointerType` API | https://qir-alliance.github.io/pyqir/api/pyqir.html#pyqir.PointerType |
| pyqir `qis.if_result` | https://qir-alliance.github.io/pyqir/api/pyqir.qis.html |
| LLVM opaque pointer migration | https://llvm.org/docs/OpaquePointers.html |
| QIR specification | https://github.com/qir-alliance/qir-spec |
| Qiskit `transpile` 2.0 changes | https://docs.quantum.ibm.com/migration-guides/qiskit-2.0 |

