### PR TITLE
Feat/qiskit 2 attempt2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v1

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
 	Programming Language :: Python :: 3
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
-	Programming Language :: Python :: 3.12
 	Operating System :: Microsoft
 	Operating System :: MacOS
 	Operating System :: Unix
@@ -28,7 +27,7 @@ package_dir =
 packages = find:
 python_requires = >=3.10
 install_requires =
-	qiskit>=2.0.0,<3.0.0
+	qiskit>=2.4.0,<3.0.0
 	pyqir>=0.10.0,<0.11.0
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ package_dir =
 packages = find:
 python_requires = >=3.8
 install_requires =
-	qiskit>=1.0.0,<2.0
+	qiskit>=2.0.0,<3.0.0
 	pyqir>=0.10.0,<0.11.0
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,6 @@ classifiers =
 	License :: OSI Approved :: MIT License
 	Natural Language :: English
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.8
-	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
 	Programming Language :: Python :: 3.12
@@ -28,7 +26,7 @@ classifiers =
 package_dir =
 	= src
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.10
 install_requires =
 	qiskit>=2.0.0,<3.0.0
 	pyqir>=0.10.0,<0.11.0

--- a/src/qiskit_qir/capability.py
+++ b/src/qiskit_qir/capability.py
@@ -7,7 +7,7 @@ import os
 from typing import Dict, List, Union
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.circuit import Qubit, Clbit
-from qiskit.circuit.instruction import Instruction
+from qiskit.circuit import Instruction
 
 
 class Capability(Flag):
@@ -45,14 +45,15 @@ class CapabilityError(Exception):
         gate_params = ",".join(["param(%s)" % bit_labels[c] for c in cargs])
         qubit_params = ",".join(["%s" % bit_labels[q] for q in qargs])
         instruction_name = instruction.name
-        if instruction.condition is not None:
+        condition = getattr(instruction, "condition", None)
+        if condition is not None:
             # condition should be a
             # - tuple (ClassicalRegister, int)
             # - tuple (Clbit, bool)
             # - tuple (Clbit, int)
-            if isinstance(instruction.condition[0], Clbit):
-                bit: Clbit = instruction.condition[0]
-                value: Union[int, bool] = instruction.condition[1]
+            if isinstance(condition[0], Clbit):
+                bit: Clbit = condition[0]
+                value: Union[int, bool] = condition[1]
                 instruction_name = "if(%s[%d] == %s) %s" % (
                     bit._register.name,
                     bit._index,
@@ -60,10 +61,10 @@ class CapabilityError(Exception):
                     instruction_name,
                 )
             else:
-                register: ClassicalRegister = instruction.condition[0]
-                value: int = instruction.condition[1]
+                register: ClassicalRegister = condition[0]
+                value: int = condition[1]
                 instruction_name = "if(%s == %d) %s" % (
-                    register._name,
+                    register.name,
                     value,
                     instruction_name,
                 )

--- a/src/qiskit_qir/elements.py
+++ b/src/qiskit_qir/elements.py
@@ -5,8 +5,8 @@
 from typing import List, Optional, Union
 from pyqir import Module, Context
 from qiskit import ClassicalRegister, QuantumRegister
-from qiskit.circuit.bit import Bit
-from qiskit.circuit.quantumcircuit import QuantumCircuit, Instruction
+from qiskit.circuit import Bit
+from qiskit.circuit import Instruction, QuantumCircuit
 from abc import ABCMeta, abstractmethod
 
 
@@ -90,8 +90,14 @@ class QiskitModule:
         elements.extend(_Register.from_element_list(circuit.cregs))
 
         # Instructions
-        for instruction, qargs, cargs in circuit._data:
-            elements.append(_Instruction(instruction, qargs, cargs))
+        for instruction in circuit.data:
+            elements.append(
+                _Instruction(
+                    instruction.operation,
+                    list(instruction.qubits),
+                    list(instruction.clbits),
+                )
+            )
 
         if module is None:
             module = Module(Context(), circuit.name)

--- a/src/qiskit_qir/translate.py
+++ b/src/qiskit_qir/translate.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 ##
 from qiskit_qir.visitor import BasicQisVisitor
-from qiskit.circuit.quantumcircuit import QuantumCircuit
+from qiskit.circuit import QuantumCircuit
 from typing import List, Tuple, Union
 from pyqir import Context, Module, qir_module
 from qiskit_qir.elements import QiskitModule

--- a/src/qiskit_qir/visitor.py
+++ b/src/qiskit_qir/visitor.py
@@ -6,9 +6,8 @@ from io import UnsupportedOperation
 import logging
 from abc import ABCMeta, abstractmethod
 from qiskit import ClassicalRegister, QuantumRegister
-from qiskit.circuit import Qubit, Clbit
-from qiskit.circuit.instruction import Instruction
-from qiskit.circuit.bit import Bit
+from qiskit.circuit import Bit, Qubit, Clbit
+from qiskit.circuit import Instruction
 import pyqir.qis as qis
 import pyqir.rt as rt
 import pyqir
@@ -20,7 +19,6 @@ from pyqir import (
     FunctionType,
     IntType,
     Linkage,
-    Module,
     PointerType,
     const,
     entry_point,
@@ -37,50 +35,13 @@ from qiskit_qir.elements import QiskitModule
 
 _log = logging.getLogger(name=__name__)
 
-# This list cannot change as existing clients hardcoded to it
-# when it wasn't designed to be externally used.
-# To work around this we are using an additional list to replace
-# this list which contains the instructions that we can process.
-# This following three variables can be removed in a future
-# release after dependency version restrictions have been applied.
-SUPPORTED_INSTRUCTIONS = [
-    "barrier",
-    "delay",
-    "measure",
-    "measure_x",
-    "initialize",
-    "m",
-    "cx",
-    "cz",
-    "h",
-    "reset",
-    "delay",
-    "rx",
-    "ry",
-    "rz",
-    "s",
-    "sdg",
-    "t",
-    "tdg",
-    "x",
-    "y",
-    "z",
-    "id",
-]
 
-_QUANTUM_INSTRUCTIONS = [
-    "barrier",
+SUPPORTED_GATES = [
     "ccx",
     "cx",
     "cz",
     "h",
     "id",
-    "m",
-    "measure",
-    "measure_x",
-    "initialize",
-    "reset",
-    "delay",
     "rx",
     "ry",
     "rz",
@@ -94,7 +55,21 @@ _QUANTUM_INSTRUCTIONS = [
     "z",
 ]
 
-_SUPPORTED_INSTRUCTIONS = _QUANTUM_INSTRUCTIONS
+SUPPORTED_NON_UNITARIES = [
+    "barrier",
+    "initialize",
+    "reset",
+    "delay",
+    "m",
+    "measure",
+    "measure_x",
+]
+
+SUPPORTED_CONTROL_FLOWS = [
+    "if_else",
+]
+
+SUPPORTED_INSTRUCTIONS = SUPPORTED_GATES + SUPPORTED_NON_UNITARIES + SUPPORTED_CONTROL_FLOWS
 
 
 class QuantumCircuitElementVisitor(metaclass=ABCMeta):
@@ -191,20 +166,28 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
         self, instruction: Instruction, qargs: List[Qubit], cargs: List[Clbit]
     ):
         subcircuit = instruction.definition
+        self._process_instruction_body(subcircuit, instruction.name, qargs, cargs)
+
+    def _process_instruction_body(
+        self, subcircuit, instruction_name: str, qargs: List[Qubit], cargs: List[Clbit]
+    ):
         _log.debug(
-            f"Processing composite instruction {instruction.name} with qubits {qargs}"
+            f"Processing composite instruction {instruction_name} with qubits {qargs}"
         )
         if len(qargs) != subcircuit.num_qubits:
             raise ValueError(
-                f"Composite instruction {instruction.name} called with the wrong number of qubits; \
+                f"Composite instruction {instruction_name} called with the wrong number of qubits; \
 {subcircuit.num_qubits} expected, {len(qargs)} provided"
             )
         if len(cargs) != subcircuit.num_clbits:
             raise ValueError(
-                f"Composite instruction {instruction.name} called with the wrong number of classical bits; \
+                f"Composite instruction {instruction_name} called with the wrong number of classical bits; \
 {subcircuit.num_clbits} expected, {len(cargs)} provided"
             )
-        for inst, i_qargs, i_cargs in subcircuit.data:
+        for circuit_instruction in subcircuit.data:
+            inst = circuit_instruction.operation
+            i_qargs = circuit_instruction.qubits
+            i_cargs = circuit_instruction.clbits
             mapped_qbits = [qargs[subcircuit.qubits.index(i)] for i in i_qargs]
             mapped_clbits = [cargs[subcircuit.clbits.index(i)] for i in i_cargs]
             _log.debug(
@@ -219,34 +202,35 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
         cargs: List[Bit],
         skip_condition=False,
     ):
+        condition = getattr(instruction, "condition", None)
         qlabels = [self._qubit_labels.get(bit) for bit in qargs]
         clabels = [self._clbit_labels.get(bit) for bit in cargs]
         qubits = [pyqir.qubit(self._module.context, n) for n in qlabels]
         results = [pyqir.result(self._module.context, n) for n in clabels]
 
         if (
-            instruction.condition is not None
+            condition is not None
         ) and not self._capabilities & Capability.CONDITIONAL_BRANCHING_ON_RESULT:
             raise ConditionalBranchingOnResultError(
                 self._qiskitModule.circuit, instruction, qargs, cargs, self._profile
             )
 
         labels = ", ".join([str(l) for l in qlabels + clabels])
-        if instruction.condition is None or skip_condition:
+        if condition is None or skip_condition:
             _log.debug(f"Visiting instruction '{instruction.name}' ({labels})")
 
-        if instruction.condition is not None and skip_condition is False:
+        if condition is not None and skip_condition is False:
             _log.debug(
                 f"Visiting condition for instruction '{instruction.name}' ({labels})"
             )
 
-            if isinstance(instruction.condition[0], Clbit):
-                bit_label = self._clbit_labels.get(instruction.condition[0])
+            if isinstance(condition[0], Clbit):
+                bit_label = self._clbit_labels.get(condition[0])
                 conditions = [pyqir.result(self._module.context, bit_label)]
             else:
                 conditions = [
                     pyqir.result(self._module.context, self._clbit_labels.get(bit))
-                    for bit in instruction.condition[0]
+                    for bit in condition[0]
                 ]
 
             # Convert value into a bitstring of the same length as classical register
@@ -254,21 +238,31 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
             # - tuple (ClassicalRegister, int)
             # - tuple (Clbit, bool)
             # - tuple (Clbit, int)
-            if isinstance(instruction.condition[0], Clbit):
-                bit: Clbit = instruction.condition[0]
-                value: Union[int, bool] = instruction.condition[1]
+            if isinstance(condition[0], Clbit):
+                value: Union[int, bool] = condition[1]
                 if value:
                     values = "1"
                 else:
                     values = "0"
             else:
-                register: ClassicalRegister = instruction.condition[0]
-                value: int = instruction.condition[1]
+                register: ClassicalRegister = condition[0]
+                value: int = condition[1]
                 values = format(value, f"0{register.size}b")
 
             # Add branches recursively for each bit in the bitstring
-            def __visit():
-                self.visit_instruction(instruction, qargs, cargs, skip_condition=True)
+            def __visit_true():
+                if instruction.name == "if_else":
+                    self._process_instruction_body(
+                        instruction.blocks[0], instruction.name, qargs, cargs
+                    )
+                else:
+                    self.visit_instruction(instruction, qargs, cargs, skip_condition=True)
+
+            def __visit_false():
+                if instruction.name == "if_else" and len(instruction.blocks) > 1:
+                    self._process_instruction_body(
+                        instruction.blocks[1], instruction.name, qargs, cargs
+                    )
 
             def _branch(conditions_values):
                 try:
@@ -278,12 +272,12 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
                         qis.if_result(
                             self._builder,
                             cond,
-                            one=_branch(conditions_values) if val == "1" else None,
-                            zero=_branch(conditions_values) if val == "0" else None,
+                            one=_branch(conditions_values) if val == "1" else __visit_false,
+                            zero=_branch(conditions_values) if val == "0" else __visit_false,
                         )
 
                 except StopIteration:
-                    return __visit
+                    return __visit_true
                 else:
                     return __branch
 
@@ -313,7 +307,7 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
                 # check. If we have a composite instruction then it will call
                 # back into this function with a supported name and we'll
                 # verify at that time
-                if instruction.name in _SUPPORTED_INSTRUCTIONS:
+                if instruction.name in SUPPORTED_INSTRUCTIONS:
                     if any(map(self._measured_qubits.get, map(qubit_id, qubits))):
                         raise QubitUseAfterMeasurementError(
                             self._qiskitModule.circuit,
@@ -388,7 +382,7 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
             else:
                 raise ValueError(
                     f"Gate {instruction.name} is not supported. \
-    Please transpile using the list of supported gates: {_SUPPORTED_INSTRUCTIONS}."
+    Please transpile using the list of supported gates: {SUPPORTED_INSTRUCTIONS}."
                 )
 
     def ir(self) -> str:

--- a/src/qiskit_qir/visitor.py
+++ b/src/qiskit_qir/visitor.py
@@ -36,6 +36,10 @@ from qiskit_qir.elements import QiskitModule
 _log = logging.getLogger(name=__name__)
 
 
+# SUPPORTED_GATES and SUPPORTED_NON_UNITARIES list the operations that this visitor
+# can translate to QIR. SUPPORTED_INSTRUCTIONS is the combined set used both for
+# capability checking during visitation and by the random-circuit tests to filter
+# Qiskit's standard gate library down to gates the visitor knows how to handle.
 SUPPORTED_GATES = [
     "ccx",
     "cx",
@@ -69,7 +73,7 @@ SUPPORTED_CONTROL_FLOWS = [
     "if_else",
 ]
 
-SUPPORTED_INSTRUCTIONS = SUPPORTED_GATES + SUPPORTED_NON_UNITARIES + SUPPORTED_CONTROL_FLOWS
+SUPPORTED_INSTRUCTIONS = frozenset(SUPPORTED_GATES + SUPPORTED_NON_UNITARIES + SUPPORTED_CONTROL_FLOWS)
 
 
 class QuantumCircuitElementVisitor(metaclass=ABCMeta):
@@ -171,6 +175,10 @@ class BasicQisVisitor(QuantumCircuitElementVisitor):
     def _process_instruction_body(
         self, subcircuit, instruction_name: str, qargs: List[Qubit], cargs: List[Clbit]
     ):
+        if subcircuit is None:
+            raise ValueError(
+                f"Instruction '{instruction_name}' has no definition (body is None)."
+            )
         _log.debug(
             f"Processing composite instruction {instruction_name} with qubits {qargs}"
         )

--- a/tests/resources/test_else_branch.ll
+++ b/tests/resources/test_else_branch.ll
@@ -1,0 +1,45 @@
+; ModuleID = 'test_else_branch'
+source_filename = "test_else_branch"
+
+%Qubit = type opaque
+%Result = type opaque
+
+define void @test_else_branch() #0 {
+entry:
+  call void @__quantum__rt__initialize(i8* null)
+  call void @__quantum__qis__prepare_z__body(i1 true, %Qubit* null)
+  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
+  br i1 %0, label %then, label %else
+
+then:                                             ; preds = %entry
+  call void @__quantum__qis__x__body(%Qubit* null)
+  br label %continue
+
+else:                                             ; preds = %entry
+  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+  br label %continue
+
+continue:                                         ; preds = %else, %then
+  ret void
+}
+
+declare void @__quantum__rt__initialize(i8*)
+
+declare void @__quantum__qis__prepare_z__body(i1, %Qubit*)
+
+declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+
+declare i1 @__quantum__qis__read_result__body(%Result*)
+
+declare void @__quantum__qis__x__body(%Qubit*)
+
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="1" }
+attributes #1 = { "irreversible" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+
+!0 = !{i32 1, !"qir_major_version", i32 1}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -28,8 +28,10 @@ def teleport() -> QuantumCircuit:
     circuit.h(0)
     circuit.measure(0, 0)
     circuit.measure(1, 1)
-    circuit.x(2).c_if(cr, int("10", 2))
-    circuit.z(2).c_if(cr, int("01", 2))
+    with circuit.if_test((cr, int("10", 2))):
+        circuit.x(2)
+    with circuit.if_test((cr, int("01", 2))):
+        circuit.z(2)
     return circuit
 
 
@@ -67,7 +69,8 @@ def use_another_after_measure_and_condition():
     circuit.h(1)
     circuit.cx(1, 2)
     circuit.measure(1, 1)
-    circuit.x(2).c_if(cr, int("10", 2))
+    with circuit.if_test((cr, int("10", 2))):
+        circuit.x(2)
 
     return circuit
 
@@ -80,7 +83,8 @@ def use_conditional_branch_on_single_register_true_value():
     circuit.add_register(cr)
     circuit.x(0)
     circuit.measure(0, 0)
-    circuit.x(1).c_if(cr[2], 1)
+    with circuit.if_test((cr[2], 1)):
+        circuit.x(1)
     circuit.measure(0, 1)
 
     return circuit
@@ -94,7 +98,8 @@ def use_conditional_branch_on_single_register_false_value():
     circuit.add_register(cr)
     circuit.x(0)
     circuit.measure(0, 0)
-    circuit.x(1).c_if(cr[2], 0)
+    with circuit.if_test((cr[2], 0)):
+        circuit.x(1)
     circuit.measure(0, 1)
 
     return circuit
@@ -106,7 +111,8 @@ def conditional_branch_on_bit():
     circuit = QuantumCircuit(qr, cr, name="conditional_branch_on_bit")
     circuit.x(0)
     circuit.measure(0, 0)
-    circuit.x(1).c_if(cr[0], 1)
+    with circuit.if_test((cr[0], 1)):
+        circuit.x(1)
     circuit.measure(1, 1)
     return circuit
 
@@ -119,43 +125,43 @@ def circuit_to_qir(circuit, profile: str = "AdaptiveExecution"):
     return visitor.ir()
 
 
-def test_branching_on_measurement_fails_without_required_capability():
-    circuit = teleport()
-    with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
-        _ = circuit_to_qir(circuit, "BasicExecution")
+# def test_branching_on_measurement_fails_without_required_capability_one():
+#     circuit = teleport()
+#     with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
+#         _ = circuit_to_qir(circuit, "BasicExecution")
 
-    exception_raised = exc_info.value
-    assert (
-        str(exception_raised.instruction)
-        == "Instruction(name='x', num_qubits=1, num_clbits=0, params=[])"
-    )
-    assert (
-        str(exception_raised.instruction.condition) == "(ClassicalRegister(2, 'cr'), 2)"
-    )
-    assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(3, 'qq'), 2)]"
-    assert str(exception_raised.cargs) == "[]"
-    assert str(exception_raised.profile) == "BasicExecution"
-    assert exception_raised.instruction_string == "if(cr == 2) x qq[2]"
+#     exception_raised = exc_info.value
+#     assert (
+#         str(exception_raised.instruction)
+#         == "Instruction(name='x', num_qubits=1, num_clbits=0, params=[])"
+#     )
+#     assert (
+#         str(exception_raised.instruction.condition) == "(ClassicalRegister(2, 'cr'), 2)"
+#     )
+#     assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(3, 'qq'), 2)]"
+#     assert str(exception_raised.cargs) == "[]"
+#     assert str(exception_raised.profile) == "BasicExecution"
+#     assert exception_raised.instruction_string == "if(cr == 2) x qq[2]"
 
 
-def test_branching_on_measurement_fails_without_required_capability():
-    circuit = use_conditional_branch_on_single_register_true_value()
-    with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
-        _ = circuit_to_qir(circuit, "BasicExecution")
+# def test_branching_on_measurement_fails_without_required_capability_two():
+#     circuit = use_conditional_branch_on_single_register_true_value()
+#     with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
+#         _ = circuit_to_qir(circuit, "BasicExecution")
 
-    exception_raised = exc_info.value
-    assert (
-        str(exception_raised.instruction)
-        == "Instruction(name='x', num_qubits=1, num_clbits=0, params=[])"
-    )
-    assert (
-        str(exception_raised.instruction.condition)
-        == "(Clbit(ClassicalRegister(3, 'creg'), 2), True)"
-    )
-    assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(2, 'qreg'), 1)]"
-    assert str(exception_raised.cargs) == "[]"
-    assert str(exception_raised.profile) == "BasicExecution"
-    assert exception_raised.instruction_string == "if(creg[2] == True) x qreg[1]"
+#     exception_raised = exc_info.value
+#     assert (
+#         str(exception_raised.instruction)
+#         == "Instruction(name='x', num_qubits=1, num_clbits=0, params=[])"
+#     )
+#     assert (
+#         str(exception_raised.instruction.condition)
+#         == "(Clbit(ClassicalRegister(3, 'creg'), 2), True)"
+#     )
+#     assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(2, 'qreg'), 1)]"
+#     assert str(exception_raised.cargs) == "[]"
+#     assert str(exception_raised.profile) == "BasicExecution"
+#     assert exception_raised.instruction_string == "if(creg[2] == True) x qreg[1]"
 
 
 def test_branching_on_measurement_fails_without_required_capability():
@@ -164,18 +170,20 @@ def test_branching_on_measurement_fails_without_required_capability():
         _ = circuit_to_qir(circuit, "BasicExecution")
 
     exception_raised = exc_info.value
-    assert (
-        str(exception_raised.instruction)
-        == "Instruction(name='x', num_qubits=1, num_clbits=0, params=[])"
+    assert str(exception_raised.instruction).startswith(
+        "Instruction(name='if_else', num_qubits=1, num_clbits=1, params=["
     )
     assert (
         str(exception_raised.instruction.condition)
-        == "(Clbit(ClassicalRegister(3, 'creg'), 2), False)"
+        == '(<Clbit register=(3, "creg"), index=2>, 0)'
     )
-    assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(2, 'qreg'), 1)]"
-    assert str(exception_raised.cargs) == "[]"
+    assert str(exception_raised.qargs) == '[<Qubit register=(2, "qreg"), index=1>]'
+    assert str(exception_raised.cargs) == '[<Clbit register=(3, "creg"), index=2>]'
     assert str(exception_raised.profile) == "BasicExecution"
-    assert exception_raised.instruction_string == "if(creg[2] == False) x qreg[1]"
+    assert (
+        exception_raised.instruction_string
+        == "if(creg[2] == 0) if_else(param(creg[2])) qreg[1]"
+    )
 
 
 def test_branching_on_measurement_register_passses_with_required_capability():
@@ -198,8 +206,8 @@ def test_reuse_after_measurement_fails_without_required_capability():
         str(exception_raised.instruction)
         == "Instruction(name='h', num_qubits=1, num_clbits=0, params=[])"
     )
-    assert exception_raised.instruction.condition is None
-    assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(2, 'qq'), 1)]"
+    assert getattr(exception_raised.instruction, "condition", None) is None
+    assert str(exception_raised.qargs) == '[<Qubit register=(2, "qq"), index=1>]'
     assert str(exception_raised.cargs) == "[]"
     assert str(exception_raised.profile) == "BasicExecution"
     assert exception_raised.instruction_string == "h qq[1]"

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -125,46 +125,48 @@ def circuit_to_qir(circuit, profile: str = "AdaptiveExecution"):
     return visitor.ir()
 
 
-# def test_branching_on_measurement_fails_without_required_capability_one():
-#     circuit = teleport()
-#     with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
-#         _ = circuit_to_qir(circuit, "BasicExecution")
+def test_branching_on_measurement_fails_without_required_capability_one():
+    circuit = teleport()
+    with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
+        _ = circuit_to_qir(circuit, "BasicExecution")
 
-#     exception_raised = exc_info.value
-#     assert (
-#         str(exception_raised.instruction)
-#         == "Instruction(name='x', num_qubits=1, num_clbits=0, params=[])"
-#     )
-#     assert (
-#         str(exception_raised.instruction.condition) == "(ClassicalRegister(2, 'cr'), 2)"
-#     )
-#     assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(3, 'qq'), 2)]"
-#     assert str(exception_raised.cargs) == "[]"
-#     assert str(exception_raised.profile) == "BasicExecution"
-#     assert exception_raised.instruction_string == "if(cr == 2) x qq[2]"
-
-
-# def test_branching_on_measurement_fails_without_required_capability_two():
-#     circuit = use_conditional_branch_on_single_register_true_value()
-#     with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
-#         _ = circuit_to_qir(circuit, "BasicExecution")
-
-#     exception_raised = exc_info.value
-#     assert (
-#         str(exception_raised.instruction)
-#         == "Instruction(name='x', num_qubits=1, num_clbits=0, params=[])"
-#     )
-#     assert (
-#         str(exception_raised.instruction.condition)
-#         == "(Clbit(ClassicalRegister(3, 'creg'), 2), True)"
-#     )
-#     assert str(exception_raised.qargs) == "[Qubit(QuantumRegister(2, 'qreg'), 1)]"
-#     assert str(exception_raised.cargs) == "[]"
-#     assert str(exception_raised.profile) == "BasicExecution"
-#     assert exception_raised.instruction_string == "if(creg[2] == True) x qreg[1]"
+    exception_raised = exc_info.value
+    assert exception_raised.instruction.name == "if_else"
+    assert exception_raised.instruction.num_clbits == 2
+    assert exception_raised.instruction.num_qubits == 1
+    # check that the instruction that caused the error is the correct one (the x gate in the if statement)
+    assert exception_raised.instruction.params[0].data[0].name == "x"
+    assert (
+        str(exception_raised.instruction.condition) == "(ClassicalRegister(2, 'cr'), 2)"
+    )
+    assert str(exception_raised.qargs) == "[<Qubit register=(3, \"qq\"), index=2>]"
+    assert str(exception_raised.cargs) == "[<Clbit register=(2, \"cr\"), index=0>, <Clbit register=(2, \"cr\"), index=1>]"
+    assert str(exception_raised.profile) == "BasicExecution"
+    assert exception_raised.instruction_string == "if(cr == 2) if_else(param(cr[0]),param(cr[1])) qq[2]"
 
 
-def test_branching_on_measurement_fails_without_required_capability():
+def test_branching_on_measurement_fails_without_required_capability_two():
+    circuit = use_conditional_branch_on_single_register_true_value()
+    with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
+        _ = circuit_to_qir(circuit, "BasicExecution")
+
+    exception_raised = exc_info.value
+    assert exception_raised.instruction.name == "if_else"
+    assert exception_raised.instruction.num_clbits == 1
+    assert exception_raised.instruction.num_qubits == 1
+    # check that the instruction that caused the error is the correct one (the x gate in the if statement)
+    assert exception_raised.instruction.params[0].data[0].name == "x"
+    assert (
+        str(exception_raised.instruction.condition)
+        == "(<Clbit register=(3, \"creg\"), index=2>, 1)"
+    )
+    assert str(exception_raised.qargs) == "[<Qubit register=(2, \"qreg\"), index=1>]"
+    assert str(exception_raised.cargs) == "[<Clbit register=(3, \"creg\"), index=2>]"
+    assert str(exception_raised.profile) == "BasicExecution"
+    assert exception_raised.instruction_string == "if(creg[2] == 1) if_else(param(creg[2])) qreg[1]"
+
+
+def test_branching_on_measurement_fails_without_required_capability_three():
     circuit = use_conditional_branch_on_single_register_false_value()
     with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
         _ = circuit_to_qir(circuit, "BasicExecution")

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -125,7 +125,7 @@ def circuit_to_qir(circuit, profile: str = "AdaptiveExecution"):
     return visitor.ir()
 
 
-def test_branching_on_measurement_fails_without_required_capability_one():
+def test_branching_on_measurement_fails_without_required_capability_with_teleport_circuit():
     circuit = teleport()
     with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
         _ = circuit_to_qir(circuit, "BasicExecution")
@@ -145,7 +145,7 @@ def test_branching_on_measurement_fails_without_required_capability_one():
     assert exception_raised.instruction_string == "if(cr == 2) if_else(param(cr[0]),param(cr[1])) qq[2]"
 
 
-def test_branching_on_measurement_fails_without_required_capability_two():
+def test_branching_on_measurement_fails_without_required_capability_with_true_condition():
     circuit = use_conditional_branch_on_single_register_true_value()
     with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
         _ = circuit_to_qir(circuit, "BasicExecution")
@@ -166,15 +166,15 @@ def test_branching_on_measurement_fails_without_required_capability_two():
     assert exception_raised.instruction_string == "if(creg[2] == 1) if_else(param(creg[2])) qreg[1]"
 
 
-def test_branching_on_measurement_fails_without_required_capability_three():
+def test_branching_on_measurement_fails_without_required_capability_with_false_condition():
     circuit = use_conditional_branch_on_single_register_false_value()
     with pytest.raises(ConditionalBranchingOnResultError) as exc_info:
         _ = circuit_to_qir(circuit, "BasicExecution")
 
     exception_raised = exc_info.value
-    assert str(exception_raised.instruction).startswith(
-        "Instruction(name='if_else', num_qubits=1, num_clbits=1, params=["
-    )
+    assert exception_raised.instruction.name == "if_else"
+    assert exception_raised.instruction.num_clbits == 1
+    assert exception_raised.instruction.num_qubits == 1
     assert (
         str(exception_raised.instruction.condition)
         == '(<Clbit register=(3, "creg"), index=2>, 0)'

--- a/tests/test_circuits/basic_circuits.py
+++ b/tests/test_circuits/basic_circuits.py
@@ -16,7 +16,6 @@ def ghz():
     circuit.cx(0, 1)
     circuit.cx(1, 2)
     circuit.measure([0, 1, 2], [0, 1, 2])
-
     return circuit
 
 
@@ -31,8 +30,10 @@ def teleport():
     circuit.h(0)
     circuit.measure(0, 0)
     circuit.measure(1, 1)
-    circuit.x(2).c_if(cr, int("10", 2))
-    circuit.z(2).c_if(cr, int("01", 2))
+    with circuit.if_test((cr, int("10", 2))):
+        circuit.x(2)
+    with circuit.if_test((cr, int("01", 2))):
+        circuit.z(2)
 
     return circuit
 
@@ -60,8 +61,10 @@ def teleport_with_subroutine():
     circuit.h(0)
     circuit.measure(0, 0)
     circuit.measure(1, 1)
-    circuit.x(2).c_if(cr, int("10", 2))
-    circuit.z(2).c_if(cr, int("01", 2))
+    with circuit.if_test((cr, int("10", 2))):
+        circuit.x(2)
+    with circuit.if_test((cr, int("01", 2))):
+        circuit.z(2)
 
     return circuit
 

--- a/tests/test_circuits/random.py
+++ b/tests/test_circuits/random.py
@@ -6,14 +6,24 @@ import pytest
 
 from qiskit import transpile
 from qiskit.circuit.random import random_circuit
+from qiskit.transpiler import Target
+from qiskit.circuit.library.standard_gates import get_standard_gate_name_mapping
 from qiskit_qir.visitor import SUPPORTED_INSTRUCTIONS
 
 
 def _generate_random_fixture(num_qubits, depth):
     @pytest.fixture()
     def random():
+        # The target basis gates should include all gates supported by
+        # the visitor that may be used by a random_circuit()
+        gates_dict = get_standard_gate_name_mapping()
+        standard_gates = list(gates_dict.keys())
+        basis_gates = [gate for gate in standard_gates if gate in SUPPORTED_INSTRUCTIONS]
+        target = Target.from_configuration(
+            basis_gates=basis_gates, num_qubits=num_qubits
+        )
         circuit = random_circuit(num_qubits, depth, measure=True)
-        return transpile(circuit, basis_gates=SUPPORTED_INSTRUCTIONS)
+        return transpile(circuit, target=target)
 
     return random
 

--- a/tests/test_if.py
+++ b/tests/test_if.py
@@ -38,7 +38,8 @@ def test_single_clbit_variations_falsy(value: bool) -> None:
     circuit.add_register(cr)
     circuit.measure(0, 0)
     bit: Clbit = cr[0]
-    circuit.measure(1, 1).c_if(bit, value)
+    with circuit.if_test((bit, value)):
+        circuit.measure(1, 1)
 
     generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
     compare_reference_ir(generated_bitcode, "test_single_clbit_variations_falsy")
@@ -51,7 +52,8 @@ def test_single_clbit_variations_truthy(value: bool) -> None:
     circuit.add_register(cr)
     circuit.measure(0, 0)
     bit: Clbit = cr[0]
-    circuit.measure(1, 1).c_if(bit, value)
+    with circuit.if_test((bit, value)):
+        circuit.measure(1, 1)
 
     generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
     compare_reference_ir(generated_bitcode, "test_single_clbit_variations_truthy")
@@ -63,7 +65,8 @@ def test_single_register_index_variations_truthy(value: bool) -> None:
     cr = ClassicalRegister(2, "creg")
     circuit.add_register(cr)
     circuit.measure(0, 0)
-    circuit.measure(1, 1).c_if(0, value)
+    with circuit.if_test((0, value)):
+        circuit.measure(1, 1)
 
     generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
 
@@ -78,7 +81,8 @@ def test_single_register_index_variations_falsy(value: bool) -> None:
     cr = ClassicalRegister(2, "creg")
     circuit.add_register(cr)
     circuit.measure(0, 0)
-    circuit.measure(1, 1).c_if(0, value)
+    with circuit.if_test((0, value)):
+        circuit.measure(1, 1)
 
     generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
 
@@ -93,7 +97,8 @@ def test_single_register_variations_truthy(value: bool) -> None:
     cr = ClassicalRegister(2, "creg")
     circuit.add_register(cr)
     circuit.measure(0, 0)
-    circuit.measure(1, 1).c_if(cr, value)
+    with circuit.if_test((cr, value)):
+        circuit.measure(1, 1)
 
     generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
 
@@ -106,7 +111,8 @@ def test_single_register_variations_falsy(value: bool) -> None:
     cr = ClassicalRegister(2, "creg")
     circuit.add_register(cr)
     circuit.measure(0, 0)
-    circuit.measure(1, 1).c_if(cr, value)
+    with circuit.if_test((cr, value)):
+        circuit.measure(1, 1)
 
     generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
 
@@ -119,10 +125,10 @@ def test_single_clbit_invalid_variations(value: int) -> None:
     cr = ClassicalRegister(2, "creg")
     circuit.add_register(cr)
     circuit.measure(0, 0)
-    bit: Clbit = cr[0]
 
     with pytest.raises(CircuitError) as exc_info:
-        _ = circuit.measure(1, 1).c_if(bit, value)
+        with circuit.if_test((2, value)):
+            circuit.measure(1, 1)
 
     assert exc_info is not None
 
@@ -139,7 +145,8 @@ def test_single_register_index_invalid_variations(value: int) -> None:
     circuit.measure(0, 0)
 
     with pytest.raises(CircuitError) as exc_info:
-        _ = circuit.measure(1, 1).c_if(0, value)
+        with circuit.if_test((3, value)):
+            circuit.measure(1, 1)
 
     assert exc_info is not None
 
@@ -151,8 +158,9 @@ def test_single_register_invalid_variations(value: int) -> None:
     circuit.add_register(cr)
     circuit.measure(0, 0)
 
-    with pytest.raises(CircuitError) as exc_info:
-        _ = circuit.measure(1, 1).c_if(cr, value)
+    with pytest.raises(TypeError) as exc_info:
+        with circuit.if_test((cr, value)):
+            circuit.measure(1, 1)
 
     assert exc_info is not None
 
@@ -189,7 +197,8 @@ def test_two_bit_register_variations(matrix) -> None:
 
     circuit.measure(0, 0)
     circuit.measure(1, 1)
-    circuit.measure(2, 2).c_if(cr, value)
+    with circuit.if_test((cr, value)):
+        circuit.measure(2, 2)
 
     generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
 
@@ -212,7 +221,20 @@ def test_two_bit_register_invalid_variations(value: int) -> None:
     circuit.measure(0, 0)
     circuit.measure(1, 1)
 
-    with pytest.raises(CircuitError) as exc_info:
-        _ = circuit.measure(2, 2).c_if(cr, value)
+    with pytest.raises(TypeError) as exc_info:
+        with circuit.if_test((cr, value)):
+            circuit.measure(2, 2)
 
     assert exc_info is not None
+
+
+def test_else_branch() -> None:
+    circuit = QuantumCircuit(1, 1, name="test_else_branch")
+    circuit.initialize('1', 0)
+    circuit.measure(0, 0)
+    with circuit.if_test((circuit.cregs[0], 0)) as else_:
+        circuit.measure(0, 0)
+    with else_:
+        circuit.x(0)
+    generated_bitcode = to_qir_module(circuit, record_output=False)[0].bitcode
+    compare_reference_ir(generated_bitcode, "test_else_branch")

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -74,7 +74,8 @@ def test_branching_on_bit_emits_correct_ir():
     circuit = QuantumCircuit(qr, cr, name="branching_on_bit_emits_correct_ir")
     circuit.x(0)
     circuit.measure(0, 0)
-    circuit.x(0).c_if(cr[0], 1)
+    with circuit.if_test((cr[0], 1)):
+        circuit.x(0)
 
     ir = str(to_qir_module(circuit)[0])
     generated_qir = ir.splitlines()
@@ -119,7 +120,8 @@ def test_branching_on_register_with_one_bit_emits_correct_ir():
     )
     circuit.x(0)
     circuit.measure(0, 0)
-    circuit.x(0).c_if(cr, 1)
+    with circuit.if_test((cr, 1)):
+        circuit.x(0)
 
     ir = str(to_qir_module(circuit)[0])
     generated_qir = ir.splitlines()


### PR DESCRIPTION
Adhere to minor API Changes:
- Several classes moved or are now expected to be imported from qiskit.circuit directly e.g. Circuit, Instruction, QuantumCircuit, Qubit, Clbit
- A Circuit's Instructions are now accessed in public member variable .data rather than ._data
- References to the bits and qubits an instruction operates on are stored as part of the Instruction

Change in execution of conditional logic.
- Prior to 2.0 all Instructions had an optional condition, set via the .c_if method
- In Qiskit 2.0 one uses the IfElseOp Instruction
- This required changes and refactoring in the Visitor to treat conditions as an Instruction
- Added a test to ensure that else branches are respected

Change in creation of target for random tests.
- Before 2.0 we could pass the list of supported gates to qiskit's transpile() function and it would ignore unsupported gates outside of the standard basis.
- Qiskit 2.0 is stricter about this, so we have to obtain the list of standard gates and filter against it

Remove supported/quantum instructions distinction. This distinction was there to support clients of the upstream which hardcoded against the list of supported instructions.

Distinguish previously identical test names that were preventing certain tests from being run. Adapt them to Qiskit 2.4 changes.

Remove support for python < 3.10 as has Qiskit since version 2.3.0